### PR TITLE
Update jersey/src/main/java/org/codehaus/enunciate/modules/jersey/JerseyValidator.java

### DIFF
--- a/jersey/src/main/java/org/codehaus/enunciate/modules/jersey/JerseyValidator.java
+++ b/jersey/src/main/java/org/codehaus/enunciate/modules/jersey/JerseyValidator.java
@@ -128,7 +128,7 @@ public class JerseyValidator extends BaseValidator {
   }
 
   private boolean isExternallyManagedLifecycle(RootResource rootResource) {
-    return rootResource.getAnnotation(SpringManagedLifecycle.class) != null && rootResource.getAnnotation(ExternallyManagedLifecycle.class) != null;
+    return rootResource.getAnnotation(SpringManagedLifecycle.class) != null || rootResource.getAnnotation(ExternallyManagedLifecycle.class) != null;
   }
 
   /**


### PR DESCRIPTION
Shouldn't either of two annotations (SpringManagedLifecycle.class or ExternallyManagedLifecycle.class) be enough to determine if resource is externally managed?
