### PR TITLE
Fix handling of namespaces for XmlElementWrapper

### DIFF
--- a/docs/src/main/java/org/codehaus/enunciate/modules/docs/GenerateExampleXmlMethod.java
+++ b/docs/src/main/java/org/codehaus/enunciate/modules/docs/GenerateExampleXmlMethod.java
@@ -207,7 +207,7 @@ public class GenerateExampleXmlMethod implements TemplateMethodModelEx {
     DocumentationExample exampleInfo = element.getAnnotation(DocumentationExample.class);
     if (exampleInfo == null || !exampleInfo.exclude()) {
       if (element.isWrapped()) {
-        String namespace = element.getNamespace();
+        String namespace = element.getWrapperNamespace();
         String prefix = namespace == null ? null : ((EnunciateFreemarkerModel) FreemarkerModel.get()).getNamespacesToPrefixes().get(namespace);
         Namespace jdomNS;
         if (Namespace.XML_NAMESPACE.getURI().equals(namespace)) {


### PR DESCRIPTION
Fix the code dealing with `@XmlElementWrapper` to use `getWrapperNamespace` instead of `getNamespace`.

When a collection is annotated as follows:

``` java
@XmlElementWrapper(name = "items")
@XmlElementRef
public List<Item> getItems()
```

where Item is a base abstract type with 2 subtypes, each annotated with @XmlRootElement, one gets the following exception during doc generation:

```
java.lang.UnsupportedOperationException: No single reference for this element: multiple choices.
        at org.codehaus.enunciate.contract.jaxb.ElementRef.getNamespace(ElementRef.java:238)
        at org.codehaus.enunciate.modules.docs.GenerateExampleXmlMethod.generateExampleXml(GenerateExampleXmlMethod.java:210)
        at org.codehaus.enunciate.modules.docs.GenerateExampleXmlMethod.generateExampleXml(GenerateExampleXmlMethod.java:155)
        at org.codehaus.enunciate.modules.docs.GenerateExampleXmlMethod.exec(GenerateExampleXmlMethod.java:119)
```

This commit fixes this issue.
