### PR TITLE
ENUNCIATE-748 - obj-c module : incorrect parsing in case of empty closed element.

### DIFF
--- a/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/common.fmt
+++ b/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/common.fmt
@@ -788,7 +788,6 @@ unsigned char *_decode_base64( const xmlChar *invalue, int *outsize ) {
         }
       }
       else {
-        status = xmlTextReaderAdvanceToNextStartOrEndElement(reader);
         if (status < 1) {
           //panic: XML read error.
           [NSException raise: @"XMLReadError"


### PR DESCRIPTION
This is a fix for http://jira.codehaus.org/browse/ENUNCIATE-748

Don't AdvanceToNextStartOrEndElement when it's an EmptyElement.
