### PR TITLE
Support to differentiate web-service and java method documentation

### DIFF
--- a/core/src/main/java/org/codehaus/enunciate/contract/jaxrs/ResourceMethod.java
+++ b/core/src/main/java/org/codehaus/enunciate/contract/jaxrs/ResourceMethod.java
@@ -333,6 +333,37 @@ public class ResourceMethod extends DecoratedMethodDeclaration implements HasFac
 
     return null;
   }
+  
+  /**
+   * Support documentation of custom parameter annotation
+   * @param jd
+   * @return
+   */
+  protected HashMap<String, String> parseParamComments(String paramAnnotation, JavaDoc jd) {
+      HashMap<String, String> paramComments = new HashMap<String, String>();
+      if (jd.get(paramAnnotation) != null) {
+          for (String paramDoc : jd.get(paramAnnotation)) {
+              paramDoc = paramDoc.replaceAll("\\s", " ");
+              int spaceIndex = paramDoc.indexOf(' ');
+              if (spaceIndex == -1) {
+                  spaceIndex = paramDoc.length();
+              }
+          }
+      }
+  }
+  /**
+   * Finds comments for both @parm and @RSParam
+   * @param jd
+   * @return
+   */
+  protected HashMap<String, String> parseAllParamComments(JavaDoc jd) {
+      HashMap<String, String> paramRESTComments = parseParamComments("RSParam", jd);
+      HashMap<String, String> paramComments = parseParamComments("param", jd);
+      paramComments.putAll(paramRESTComments);
+      return paramComments;
+
+  }
+
 
   /**
    * Loads the overridden resource parameter values.
@@ -341,7 +372,8 @@ public class ResourceMethod extends DecoratedMethodDeclaration implements HasFac
    * @return The explicit resource parameters.
    */
   protected List<ResourceParameter> loadResourceParameters(ResourceMethodSignature signatureOverride) {
-    HashMap<String, String> paramComments = parseParamComments(getJavaDoc());
+      HashMap<String, String> paramComments = parseAllParamComments(getJavaDoc());
+//    HashMap<String, String> paramComments = parseParamComments(getJavaDoc());
     
     ArrayList<ResourceParameter> params = new ArrayList<ResourceParameter>();
     for (CookieParam cookieParam : signatureOverride.cookieParams()) {


### PR DESCRIPTION
In some cases java classes can be both java DAO and web services. Of course both use cases need documentation. In my case, using @Context annotation I use a Map to store all query parameters sent from a REST call and I need to document the Map parameter for java calls by javadoc and http query parameters for REST requests by enunciate. In enunciate documentation I don't have found anything for this use case. What I see is that enunciate matches queryParams inserted in @ResourceMethodSignature with @param annotation in javadoc. What I suggest is to allow overriding the default behavior supporting also @RSParam annotation. For example:
/**
- some documentation
- @param map a MultivaluedMap 
- @RSParam queryParam a query param
  *
- @return a Bean
  **/
  @GET
  @Produces({ MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
  @ResourceMethodSignature(queryParams={@QueryParam("queryParam")})
  public Bean getBean(@Context MultivaluedMap<String,String> map){
  ....
  }

With my proposal enunciate matches the queryParam with @RSParam annotation for producing the REST documentation.
