### PR TITLE
ENUNCIATE-785: correct reference to "jsonElement" in docs.xml

### DIFF
--- a/docs/src/main/java/org/codehaus/enunciate/modules/docs/JsonSchemaForType.java
+++ b/docs/src/main/java/org/codehaus/enunciate/modules/docs/JsonSchemaForType.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.codehaus.enunciate.apt.EnunciateFreemarkerModel;
 import org.codehaus.enunciate.contract.jaxrs.ResourceEntityParameter;
+import org.codehaus.enunciate.contract.jaxrs.ResourceRepresentationMetadata;
 import org.codehaus.enunciate.contract.json.JsonSchemaInfo;
 import org.codehaus.enunciate.contract.json.JsonType;
 import org.codehaus.enunciate.contract.json.JsonTypeDefinition;
@@ -49,6 +50,13 @@ public class JsonSchemaForType implements TemplateMethodModelEx {
     if (object instanceof String) {
       final String typeName = (String) object;
       final JsonType jsonType = model.findJsonTypeDefinition(typeName);
+      return jsonSchemaForType(jsonType);
+    }
+
+    if (object instanceof ResourceRepresentationMetadata) {
+      ResourceRepresentationMetadata metadata = (ResourceRepresentationMetadata) object;
+      TypeMirror typeMirror = metadata.getDelegate();
+      final JsonType jsonType = model.findJsonTypeDefinition(typeMirror.toString());
       return jsonSchemaForType(jsonType);
     }
 

--- a/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.xml.fmt
+++ b/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.xml.fmt
@@ -401,7 +401,7 @@
         [#if resource.representationMetadata??]
           <outValue>
             [#if schemaForNamespace(resource.representationMetadata)??]<xmlElement elementSchemaId="${schemaForNamespace(resource.representationMetadata).id}" elementNamespace="${resource.representationMetadata.xmlElement.namespace!""}" elementName="${resource.representationMetadata.xmlElement.name}" />[/#if]
-            [#if jsonSchemaForType(resource.representationMetadata)??]<jsonElement elementName="${resource.representationMetadata.jsonType.typeName}" elementSchemaId="${jsonSchemaForType(resource.representationMetadata).schemaId}"/>[/#if]
+            [#if jsonSchemaForType(resource.representationMetadata)??]<jsonElementRef elementName="${resource.representationMetadata.jsonType.typeName}" elementSchemaId="${jsonSchemaForType(resource.representationMetadata).schemaId}"/>[/#if]
             <documentation><![CDATA[${resource.representationMetadata.docValue!"(no documentation provided)"}]]></documentation>
           </outValue>
         [/#if]


### PR DESCRIPTION
This bug is caused by two error in sequence:
1. the element is never generated in docs.xml, because the ResourceRepresentationMetadata is not supported datatype descriptor (it's actually just wrapper around TypeMirror, so it's easy to fix)
2. generated name is jsonElement, but docs.fmt references jsonElementRef (which is probably correct, because this name us used by input arguments)
