### PR TITLE
Improve swagger summary for endpoint methods

### DIFF
--- a/swagger/src/main/resources/org/codehaus/enunciate/modules/swagger/swagger.fmt
+++ b/swagger/src/main/resources/org/codehaus/enunciate/modules/swagger/swagger.fmt
@@ -83,10 +83,11 @@
         [/#if]
         ],
         [#if resource.docValue??]
-          [#if resource.docValue?length < 60]
-        "summary" : "${resource.docValue?json_string}",
+          [#assign summary="${resource.docValue?split('\n')?first?replace('</?[^>]+(>|$)', '', 'r')}"/]
+          [#if summary?length < 60]
+        "summary" : "${summary?json_string}",
           [#else]
-        "summary" : "${resource.docValue?substring(0, 60)?json_string}",
+        "summary" : "${summary?substring(0, 59)?json_string}…",
           [/#if]
         "notes" : "${resource.docValue?json_string}",
         [/#if]


### PR DESCRIPTION
- remove html code from summary (can break html code)
- only use one line for summary
- add … to end of summary if it's cutted
