### PR TITLE
ENUNCIATE-748 objc parser: fix bug self-close xml without wrapper

### DIFF
--- a/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/client-complex-type.fmt
+++ b/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/client-complex-type.fmt
@@ -909,9 +909,18 @@
                    format: @"Error reading element value."];
     }
     __child = [NSValue value: _child_accessor withObjCType: @encode(${classnameFor(choice.collectionItemType)})];
-              [#else]
-    __child = [${classnameFor(choice.collectionItemType)} readXMLType: reader];
-              [/#if]
+               [#else]
+                  [#if element.wrapped]
+    if(xmlTextReaderIsEmptyElement(reader) != 0){
+      __child = [[${classnameFor(choice.collectionItemType)} alloc] init];
+      xmlTextReaderAdvanceToNextStartOrEndElement(reader);
+    }else{
+      __child = [${classnameFor(choice.collectionItemType)} readXMLType: reader];
+    }
+                  [#else]
+     __child = [${classnameFor(choice.collectionItemType)} readXMLType: reader];
+                  [/#if]
+               [/#if]
             [#else]
     __child = [${classnameFor(choice)} readXMLType: reader];
             [/#if]

--- a/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/common.fmt
+++ b/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/common.fmt
@@ -787,14 +787,6 @@ unsigned char *_decode_base64( const xmlChar *invalue, int *outsize ) {
           }
         }
       }
-      else {
-        status = xmlTextReaderAdvanceToNextStartOrEndElement(reader);
-        if (status < 1) {
-          //panic: XML read error.
-          [NSException raise: @"XMLReadError"
-                       format: @"Error advancing past an empty child element."];
-        }
-      }
     }
   }
   return self;

--- a/obj-c/src/test/java/org/codehaus/enunciate/modules/objc/TestObjCSerialization.java
+++ b/obj-c/src/test/java/org/codehaus/enunciate/modules/objc/TestObjCSerialization.java
@@ -1,4 +1,4 @@
-package org.codehaus.enunciate.modules.objc;
+	package org.codehaus.enunciate.modules.objc;
 
 import junit.framework.TestCase;
 import org.codehaus.enunciate.XmlQNameEnumUtil;
@@ -11,6 +11,8 @@ import org.codehaus.enunciate.examples.objc.schema.structures.HouseStyle;
 import org.codehaus.enunciate.examples.objc.schema.structures.HouseType;
 import org.codehaus.enunciate.examples.objc.schema.vehicles.Bus;
 import org.codehaus.enunciate.examples.objc.schema.vehicles.BusType;
+import org.codehaus.enunciate.examples.objc.schema.vehicles.Seat;
+import org.codehaus.enunciate.examples.objc.schema.vehicles.SeatRow;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
@@ -187,6 +189,36 @@ public class TestObjCSerialization extends TestCase {
     assertNull(circle.getDots().get(1).getWhy());
     assertEquals("why3", circle.getDots().get(2).getWhy());
   }
+    
+    /**
+     * tests for http://jira.codehaus.org/browse/ENUNCIATE-748
+     */
+    public void testEmptyWithoutWrapper() throws Exception {
+        if (this.skipObjCTests) {
+            System.out.println("C tests have been disabled.");
+            return;
+        }
+        
+        Bus bus = new Bus();
+        SeatRow rowA = new SeatRow();
+        rowA.setRowName("A");
+        Seat seatA1 = new Seat();
+        seatA1.setNumber(1);
+        Seat seatA2 = new Seat(); //empty element
+        Seat seatA3 = new Seat();
+        seatA3.setNumber(3);
+        rowA.setSeats(Arrays.asList(seatA1, seatA2, seatA3));
+        bus.setSeatRows(Arrays.asList(rowA));
+        bus = processThroughXml(bus);
+        assertNotNull(bus.getSeatRows());
+        assertEquals(1, bus.getSeatRows().size());
+        List<Seat> seats =bus.getSeatRows().get(0).getSeats();
+        assertNotNull(seats);
+        assertEquals(3, seats.size());
+        assertEquals(new Integer(1), seats.get(0).getNumber());
+        assertEquals(null, seats.get(1).getNumber());
+        assertEquals(new Integer(3), seats.get(2).getNumber());
+    }
 
   /**
    * tests for http://jira.codehaus.org/browse/ENUNCIATE-766

--- a/obj-c/src/test/schema/org/codehaus/enunciate/examples/objc/schema/vehicles/Bus.java
+++ b/obj-c/src/test/schema/org/codehaus/enunciate/examples/objc/schema/vehicles/Bus.java
@@ -21,10 +21,13 @@ import org.codehaus.enunciate.examples.objc.schema.Rectangle;
 import org.codehaus.enunciate.examples.objc.schema.Circle;
 import org.codehaus.enunciate.qname.XmlQNameEnumRef;
 
+import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.namespace.QName;
+
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -38,6 +41,7 @@ public class Bus extends Figure {
   private Collection<Rectangle> windows;
   private Rectangle door;
   private QName type;
+  private List<SeatRow> seatRows;
 
   public Rectangle getFrame() {
     return frame;
@@ -83,5 +87,12 @@ public class Bus extends Figure {
     this.type = type;
   }
 
+  public List<SeatRow> getSeatRows() {
+    return seatRows;
+  }
+
+  public void setSeatRows(List<SeatRow> seatRows) {
+    this.seatRows = seatRows;
+  }
 
 }

--- a/obj-c/src/test/schema/org/codehaus/enunciate/examples/objc/schema/vehicles/Seat.java
+++ b/obj-c/src/test/schema/org/codehaus/enunciate/examples/objc/schema/vehicles/Seat.java
@@ -1,0 +1,22 @@
+package org.codehaus.enunciate.examples.objc.schema.vehicles;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+
+/**
+ * @author Martin Magakian
+ * http://doduck.com
+ */
+public class Seat {
+
+	private Integer number;
+	
+	public Integer getNumber() {
+		return number;
+	}
+	
+	public void setNumber(Integer number) {
+		this.number = number;
+	}
+
+}

--- a/obj-c/src/test/schema/org/codehaus/enunciate/examples/objc/schema/vehicles/SeatRow.java
+++ b/obj-c/src/test/schema/org/codehaus/enunciate/examples/objc/schema/vehicles/SeatRow.java
@@ -1,0 +1,37 @@
+package org.codehaus.enunciate.examples.objc.schema.vehicles;
+
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Martin Magakian
+ * http://doduck.com
+ */
+public class SeatRow {
+	
+	private String rowName;
+	private List<Seat> seats;
+
+	public SeatRow() {
+	}
+	
+	public List<Seat> getSeats() {
+		return seats;
+	}
+
+	public void setSeats(List<Seat> seats) {
+		this.seats = seats;
+	}
+
+	public String getRowName() {
+		return rowName;
+	}
+
+	public void setRowName(String rowName) {
+		this.rowName = rowName;
+	}
+	
+}


### PR DESCRIPTION
The Objective-C parser is not able to handle XML properly when parsing a XML with <b>self-closing tag without a wrapper.</b>

Example without wrapper (bug):

``` xml
    <bus>
        <seatRows>
            <seats>
                <number>1</number>
            </seats>
            <seats/>
            <seats>
                <number>3</number>
            </seats>
        </seatRows>
    </bus>
```

<br />
Example with wrapper (working):

``` xml
    <bus>
        <seatRows>
            <listSeat>
                <seats>
                    <number>1</number>
                </seats>
                <seats/>
                <seats>
                    <number>3</number>
                </seats>
            </listSeat>
        </seatRows>
    </bus>
```

<br />
Without wapping, the generated parser will call 2 times `xmlTextReaderAdvanceToNextStartOrEndElement` when it find a self-closing tag.
As a result it jump the self-close tag and an extra element.

Following [TristanBrismontier](https://github.com/stoicflame/enunciate/pull/17) work, I implemented a unit test who reproduce the bug and correct it.

Martin Magakian,
<a href="http://doduck.com">doduck prototype</a>
