### PR TITLE
objc - Fix enum util

### DIFF
--- a/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/client-enum-type.fmt
+++ b/obj-c/src/main/resources/org/codehaus/enunciate/modules/objc/client-enum-type.fmt
@@ -42,7 +42,7 @@ static int xmlTextWriterWrite${typeName}Type(xmlTextWriterPtr writer, enum ${typ
  * @param _${type.clientSimpleName?uncap_first} The string to format.
  * @return The enum value or NULL on error.
  */
-enum ${typeName} *formatStringTo${typeName}Type(NSString *_${type.clientSimpleName?uncap_first});
+static enum ${typeName} *formatStringTo${typeName}Type(NSString *_${type.clientSimpleName?uncap_first});
 
 /**
  * Utility method for getting the string value of ${type.clientSimpleName}.
@@ -50,7 +50,7 @@ enum ${typeName} *formatStringTo${typeName}Type(NSString *_${type.clientSimpleNa
  * @param _${type.clientSimpleName?uncap_first} The ${type.clientSimpleName} to format.
  * @return The string value or NULL on error.
  */
-NSString *format${typeName}TypeToString(enum ${typeName} *_${type.clientSimpleName?uncap_first});
+static NSString *format${typeName}TypeToString(enum ${typeName} *_${type.clientSimpleName?uncap_first});
   [#else]
 /**
  * Gets the known ${type.clientSimpleName} for a QName.
@@ -120,17 +120,21 @@ enum ${typeName} *formatStringTo${typeName}Type(NSString *_${type.clientSimpleNa
     [#assign enumValueMap=type.enumValues/]
     [#list type.enumConstants as constant]
       [#if constant_index == 0]
-  [#if constant_index != 0]else [/#if]if (${"[@"}"${enumValueMap[constant.simpleName]}" isEqualToString:_${type.clientSimpleName?uncap_first}]) {
+  if (${"[@"}"${enumValueMap[constant.simpleName]}" isEqualToString:_${type.clientSimpleName?uncap_first}]) {
     *value = ${nameForEnumConstant(type, constant)};
-  } 
+  }
+      [#else]
+  else if (${"[@"}"${enumValueMap[constant.simpleName]}" isEqualToString:_${type.clientSimpleName?uncap_first}]) {
+    *value = ${nameForEnumConstant(type, constant)};
+  }
+    [/#if]
     [/#list]
   else{
-    #if DEBUG_ENUNCIATE
-    NSLog(@"Attempt to read enum value failed: %s doesn't match an enum value.", [_${type.clientSimpleName?uncap_first} UTF8String]);
-    #endif
+#if DEBUG_ENUNCIATE
+  NSLog(@"Attempt to read enum value failed: %s doesn't match an enum value.", [_${type.clientSimpleName?uncap_first} UTF8String]);
+#endif
     value = NULL;
   }
-
   return value;
 }
 
@@ -163,7 +167,7 @@ static int xmlTextWriterWrite${typeName}Type(xmlTextWriterPtr writer, enum ${typ
  * @param _${type.clientSimpleName?uncap_first} The ${type.clientSimpleName} to format.
  * @return The string value or NULL on error.
  */
-NSString *format${typeName}TypeToString(enum ${typeName} *_${type.clientSimpleName?uncap_first})
+static NSString *format${typeName}TypeToString(enum ${typeName} *_${type.clientSimpleName?uncap_first})
 {
   switch (*_${type.clientSimpleName?uncap_first}) {
     [#assign enumValueMap=type.enumValues/]


### PR DESCRIPTION
Enunciate generate some utils function to manipulate enum in Objective-C.
On of this function is forgetting the last element of the enum.

See ticket:
https://jira.codehaus.org/browse/ENUNCIATE-818

Martin Magakian
http://doduck.com
