### PR TITLE
Fix: jaxrs possibility to use valueOf method as a parameter

### DIFF
--- a/core/src/main/java/org/codehaus/enunciate/contract/validation/DefaultValidator.java
+++ b/core/src/main/java/org/codehaus/enunciate/contract/validation/DefaultValidator.java
@@ -270,7 +270,9 @@ public class DefaultValidator extends BaseValidator implements ConfigurableRules
         }
 
         for (MethodDeclaration method : declaration.getMethods()) {
-          if (method.getModifiers().contains(Modifier.STATIC) && "valueOf".equals(method.getSimpleName()) && isString(method.getReturnType())) {
+          if (method.getModifiers().contains(Modifier.STATIC) && "valueOf".equals(method.getSimpleName()) &&
+        		  method.getReturnType().equals(type) &&
+        		  method.getParameters().size() == 1 && isString(method.getParameters().iterator().next().getType())) {
             return true;
           }
         }


### PR DESCRIPTION
valueOf should be a static method that takes a String as a parameter and returns a constructed type instance. Current implementation seems to be wrong
