### PR TITLE
Fix docs generation for @SampleResponse and @StatusCodes

### DIFF
--- a/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.fmt
+++ b/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.fmt
@@ -861,7 +861,7 @@ Content-Type: [#assign first = true/][#list operation.contentType as contentType
             [#list docsxml.data.schema as schema]
                 [#list schema.elements.element?sort_by("@name") as element]
                     [#if xmlElement.@elementName == element.@name]
-                        [#if operation.showSampleRequest == "JSON"]
+                        [#if operation.showSampleResponse == "JSON"]
                             [#list element.examplejson as examplejson]
 ${examplejson?string?xhtml}
                             [/#list]
@@ -886,7 +886,7 @@ ${examplexml?string?xhtml}
         <tr>
           <th width="130">HTTP Status Code</th>
           <th>Description</th>
-          [#list resource.additionalHeaderLabels.label as label]
+          [#list operation.additionalHeaderLabels.label as label]
           <th>${label}</th>
           [/#list]
         </tr>

--- a/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.xml.fmt
+++ b/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.xml.fmt
@@ -356,15 +356,15 @@
     [#list resources as resource]
       [#if resource.label??]
     <label>${resource.label}</label>
-      [/#if]
-        <additionalHeaderLabels>
-      [#list resource.additionalHeaderLabels as headerLabel]
-          <label>${headerLabel}</label>
-      [/#list]
-        </additionalHeaderLabels>
+      [/#if]        
       [#if resource.httpMethods?size > 0]
         [#if !isFacetExcluded(resource)]
         <operation name="${resource.httpMethods?first}">
+            <additionalHeaderLabels>
+          [#list resource.additionalHeaderLabels as headerLabel]
+              <label>${headerLabel}</label>
+          [/#list]
+            </additionalHeaderLabels>
           [#if resource.docValue??]
           <documentation>
             <![CDATA[${resource.docValue}]]>
@@ -374,7 +374,7 @@
             <showSampleRequest>${resource.showSampleRequest}</showSampleRequest>
           [/#if]
           [#if resource.showSampleResponse??]
-            <showSampleResponse code="${resource.sampleResponseCode}">${resource.showSampleRequest}</showSampleResponse>
+            <showSampleResponse code="${resource.sampleResponseCode}">${resource.sampleResponseCode}</showSampleResponse>
           [/#if]
           [#if resource.customParameterName??]
             <customParameterName>${resource.customParameterName}</customParameterName>


### PR DESCRIPTION
I noticed two little bugs in the code that i provided earlier and fixed them:
1. SampleResponse couldn't be shown without SampleRequest
2. The StatusCodes table showed a redundant <th> column, when there is more than one operation with same path
