### PR TITLE
Add simple check for value of parameter.xmlType.qname before using.

### DIFF
--- a/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.xml.fmt
+++ b/docs/src/main/resources/org/codehaus/enunciate/modules/docs/docs.xml.fmt
@@ -414,7 +414,7 @@
             [/#if]
           [/#list]
           [#list resource.resourceParameters as parameter]
-          <parameter name="${parameter.parameterName}" type="${parameter.typeName!"custom"}"[#if parameter.defaultValue??] defaultValue="${parameter.defaultValue}"[/#if][#if parameter.xmlType??] xmlTypeName="${parameter.xmlType.qname.localPart}" xmlTypeNamespace="${parameter.xmlType.qname.namespaceURI}"[/#if]>
+          <parameter name="${parameter.parameterName}" type="${parameter.typeName!"custom"}"[#if parameter.defaultValue??] defaultValue="${parameter.defaultValue}"[/#if][#if parameter.xmlType?? && parameter.xmlType.qname??] xmlTypeName="${parameter.xmlType.qname.localPart}" xmlTypeNamespace="${parameter.xmlType.qname.namespaceURI}"[/#if]>
             <![CDATA[${parameter.docValue!"(no documentation provided)"}]]>
           </parameter>
           [/#list]


### PR DESCRIPTION
Overcomes a problem when using custom types. For example: 

``` xml
<custom-resource-parameter-annotation qualifiedName="org.glassfish.jersey.media.multipart.FormDataParam"/>
```
