### PR TITLE
Support for excluding deprecated fields in example JSON and XML.

### DIFF
--- a/docs/src/main/java/org/codehaus/enunciate/modules/docs/DocumentationDeploymentModule.java
+++ b/docs/src/main/java/org/codehaus/enunciate/modules/docs/DocumentationDeploymentModule.java
@@ -205,6 +205,7 @@ public class DocumentationDeploymentModule extends FreemarkerDeploymentModule im
   private boolean includeDefaultDownloads = true;
   private boolean includeExampleXml = true;
   private boolean includeExampleJson = true;
+  private boolean includeDeprecatedFieldsInExample = true;
   private boolean forceExampleJson = false;
   private String xslt;
   private URL xsltURL;
@@ -419,6 +420,24 @@ public class DocumentationDeploymentModule extends FreemarkerDeploymentModule im
    */
   public void setIncludeExampleJson(boolean includeExampleJson) {
     this.includeExampleJson = includeExampleJson;
+  }
+
+  /**
+   * Whether to include deprecated fields in example JSON and example XML.
+   *
+   * @return Whether to include deprecated fields in example JSON and example XML.
+   */
+  public boolean isIncludeDeprecatedFieldsInExample() {
+    return includeDeprecatedFieldsInExample;
+  }
+
+  /**
+   * Whether to include deprecated fields in example JSON and example XML.
+   *
+   * @param includeDeprecatedFieldsInExample Whether to include deprecated fields in example JSON and example XML.
+   */
+  public void setIncludeDeprecatedFieldsInExample(boolean includeDeprecatedFieldsInExample) {
+    this.includeDeprecatedFieldsInExample = includeDeprecatedFieldsInExample;
   }
 
   /**
@@ -790,9 +809,9 @@ public class DocumentationDeploymentModule extends FreemarkerDeploymentModule im
       model.setVariable(JsonTypeNameForQualifiedName.NAME, new JsonTypeNameForQualifiedName(model));
       model.put("isDefinedGlobally", new IsDefinedGloballyMethod());
       model.put("includeExampleXml", isIncludeExampleXml());
-      model.put("generateExampleXml", new GenerateExampleXmlMethod(getDefaultNamespace(), model));
+      model.put("generateExampleXml", new GenerateExampleXmlMethod(getDefaultNamespace(), model, isIncludeDeprecatedFieldsInExample()));
       model.put("includeExampleJson", (forceExampleJson || (jacksonXcAvailable && isIncludeExampleJson())));
-      model.put("generateExampleJson", new GenerateExampleJsonMethod(model));
+      model.put("generateExampleJson", new GenerateExampleJsonMethod(model, isIncludeDeprecatedFieldsInExample()));
       processTemplate(getDocsTemplateURL(), model);
     }
     else {

--- a/docs/src/main/java/org/codehaus/enunciate/modules/docs/GenerateExampleJsonMethod.java
+++ b/docs/src/main/java/org/codehaus/enunciate/modules/docs/GenerateExampleJsonMethod.java
@@ -51,9 +51,11 @@ public class GenerateExampleJsonMethod implements TemplateMethodModelEx {
   private static final ThreadLocal<Stack<String>> TYPE_DEF_STACK = new ThreadLocal<Stack<String>>();
 
   private final EnunciateFreemarkerModel model;
+  private final boolean includeDeprecatedFieldsInExample;
 
-  public GenerateExampleJsonMethod(EnunciateFreemarkerModel model) {
+  public GenerateExampleJsonMethod(EnunciateFreemarkerModel model, boolean includeDeprecatedFieldsInExample) {
     this.model = model;
+    this.includeDeprecatedFieldsInExample = includeDeprecatedFieldsInExample;
   }
 
   public Object exec(List list) throws TemplateModelException {
@@ -175,6 +177,9 @@ public class GenerateExampleJsonMethod implements TemplateMethodModelEx {
     if (TYPE_DEF_STACK.get().size() > maxDepth) {
       return;
     }
+    if (!includeDeprecatedFieldsInExample && attribute.getAnnotation(Deprecated.class) != null) {
+      return;
+    }
 
     DocumentationExample exampleInfo = attribute.getAnnotation(DocumentationExample.class);
     if (exampleInfo == null || !exampleInfo.exclude()) {
@@ -197,6 +202,9 @@ public class GenerateExampleJsonMethod implements TemplateMethodModelEx {
 
   protected void generateExampleJson(Element element, ObjectNode jsonNode, int maxDepth) {
     if (TYPE_DEF_STACK.get().size() > maxDepth) {
+      return;
+    }
+    if (!includeDeprecatedFieldsInExample && element.getAnnotation(Deprecated.class) != null) {
       return;
     }
 

--- a/docs/src/main/java/org/codehaus/enunciate/modules/docs/GenerateExampleXmlMethod.java
+++ b/docs/src/main/java/org/codehaus/enunciate/modules/docs/GenerateExampleXmlMethod.java
@@ -17,11 +17,13 @@ package org.codehaus.enunciate.modules.docs;
 
 import com.sun.mirror.declaration.ClassDeclaration;
 import com.sun.mirror.declaration.TypeDeclaration;
+
 import freemarker.ext.beans.BeansWrapper;
 import freemarker.template.TemplateMethodModelEx;
 import freemarker.template.TemplateModel;
 import freemarker.template.TemplateModelException;
 import net.sf.jelly.apt.freemarker.FreemarkerModel;
+
 import org.codehaus.enunciate.apt.EnunciateFreemarkerModel;
 import org.codehaus.enunciate.contract.jaxb.*;
 import org.codehaus.enunciate.contract.jaxb.types.MapXmlType;
@@ -36,6 +38,7 @@ import org.jdom.output.XMLOutputter;
 
 import javax.xml.bind.annotation.XmlNsForm;
 import javax.xml.namespace.QName;
+
 import java.io.StringWriter;
 import java.util.List;
 import java.util.Stack;
@@ -53,10 +56,12 @@ public class GenerateExampleXmlMethod implements TemplateMethodModelEx {
 
   private final String defaultNamespace;
   private final EnunciateFreemarkerModel model;
+  private final boolean includeDeprecatedFieldsInExample;
 
-  public GenerateExampleXmlMethod(String defaultNamespace, EnunciateFreemarkerModel model) {
+  public GenerateExampleXmlMethod(String defaultNamespace, EnunciateFreemarkerModel model, boolean includeDeprecatedFieldsInExample) {
     this.defaultNamespace = defaultNamespace;
     this.model = model;
+    this.includeDeprecatedFieldsInExample = includeDeprecatedFieldsInExample;
   }
 
   public Object exec(List list) throws TemplateModelException {
@@ -173,6 +178,9 @@ public class GenerateExampleXmlMethod implements TemplateMethodModelEx {
   }
 
   protected void generateExampleXml(Attribute attribute, org.jdom.Element parent, String defaultNs) {
+    if (!includeDeprecatedFieldsInExample && attribute.getAnnotation(Deprecated.class) != null) {
+      return;
+    }
     DocumentationExample exampleInfo = attribute.getAnnotation(DocumentationExample.class);
     if (exampleInfo == null || !exampleInfo.exclude()) {
       String namespace = attribute.getNamespace();
@@ -202,6 +210,9 @@ public class GenerateExampleXmlMethod implements TemplateMethodModelEx {
 
   protected void generateExampleXml(Element element, org.jdom.Element parent, String defaultNs, int maxDepth) {
     if (TYPE_DEF_STACK.get().size() > maxDepth) {
+      return;
+    }
+    if (!includeDeprecatedFieldsInExample && element.getAnnotation(Deprecated.class) != null) {
       return;
     }
 


### PR DESCRIPTION
Added support for excluding fields with the @Deprecated annotation when
generating the example XML and example JSON.
