### PR TITLE
Relax version range of import package javax.ws.rs for enunciate-core-annotation

### DIFF
--- a/core-annotations/pom.xml
+++ b/core-annotations/pom.xml
@@ -27,6 +27,11 @@
         <artifactId>maven-bundle-plugin</artifactId>
         <version>3.0.1</version>
         <extensions>true</extensions>
+        <configuration>
+          <instructions>
+            <Import-Package>javax.ws.rs.*;version="[1.0,3)"</Import-Package>
+          </instructions>
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Relax version range of import package javax.ws.rs in OSGi MANIFEST.MF for enunciate-core-annotation to enable this bundle to run on server with profile Java EE 6 or less.