### PR TITLE
Fix #286 Only one ResourceMethodSignature query param appears in documentation

### DIFF
--- a/docs/template/resource.html
+++ b/docs/template/resource.html
@@ -129,8 +129,8 @@
                 <thead>
                 <tr>
                   <th>name</th>
-                  <th>description</th>
                   <th>type</th>
+                  <th>description</th>
                   <th>default</th>
                 </tr>
                 </thead>

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ExplicitResourceParameter.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ExplicitResourceParameter.java
@@ -1,11 +1,12 @@
 package com.webcohesion.enunciate.modules.jaxrs.model;
 
 
+import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.modules.jaxrs.EnunciateJaxrsContext;
 
 /**
  * A resource parameter with explicit values.
- * 
+ *
  * @author Ryan Heaton
  */
 public class ExplicitResourceParameter extends ResourceParameter {
@@ -21,8 +22,9 @@ public class ExplicitResourceParameter extends ResourceParameter {
     this.type = type;
   }
 
-  public String getDocValue() {
-    return docValue;
+  @Override
+  public JavaDoc getJavaDoc() {
+    return new JavaDoc(docValue, null);
   }
 
   @Override

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceParameter.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceParameter.java
@@ -16,6 +16,29 @@
 
 package com.webcohesion.enunciate.modules.jaxrs.model;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.ElementFilter;
+import javax.ws.rs.CookieParam;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.FormParam;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.MatrixParam;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+
 import com.webcohesion.enunciate.javac.decorations.ElementDecorator;
 import com.webcohesion.enunciate.javac.decorations.element.DecoratedElement;
 import com.webcohesion.enunciate.javac.decorations.element.DecoratedTypeElement;
@@ -25,14 +48,6 @@ import com.webcohesion.enunciate.javac.decorations.type.DecoratedTypeMirror;
 import com.webcohesion.enunciate.javac.decorations.type.TypeMirrorUtils;
 import com.webcohesion.enunciate.metadata.rs.TypeHint;
 import com.webcohesion.enunciate.modules.jaxrs.EnunciateJaxrsContext;
-
-import javax.lang.model.element.*;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.ElementFilter;
-import javax.ws.rs.*;
-import javax.ws.rs.core.Context;
-import java.util.*;
 
 /**
  * Parameter for a JAX-RS resource.
@@ -400,18 +415,21 @@ public class ResourceParameter extends DecoratedElement<Element> implements Comp
     }
 
     ResourceParameter that = (ResourceParameter) o;
-    return !(parameterName != null ? !parameterName.equals(that.parameterName) : that.parameterName != null) && !(typeName != null ? !typeName.equals(that.typeName) : that.typeName != null);
+    return !(getParameterName() != null ? !getParameterName().equals(that.getParameterName()) : that.getParameterName() != null) && !(getTypeName() != null ? !getTypeName().equals(that.getTypeName()) : that.getTypeName() != null);
   }
 
   @Override
   public int hashCode() {
-    int result = parameterName != null ? parameterName.hashCode() : 0;
-    result = 31 * result + (typeName != null ? typeName.hashCode() : 0);
+    String pName = getParameterName();
+    String tName = getTypeName();
+
+    int result = pName != null ? pName.hashCode() : 0;
+    result = 31 * result + (tName != null ? tName.hashCode() : 0);
     return result;
   }
 
   @Override
   public int compareTo(ResourceParameter other) {
-    return (this.typeName + this.parameterName).compareTo(other.typeName + other.parameterName);
+    return (this.getTypeName() + this.getParameterName()).compareTo(other.getTypeName() + other.getParameterName());
   }
 }


### PR DESCRIPTION
The ResourceParameter now use getter method instead field in equals, compareTo and hasCode to support extended classes.
Replace unused getDocValue method with getJavaDoc to return the custom @RSParam javadoc.
Align resource.html as generated by the freemarker template.

Maybe there speeder method to return javadoc without use JavaDoc structure that parse javadoc again.