### PR TITLE
JDK 7 build instructions & compile error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,17 @@ Enunciate runs tests for the generated client-side code that it develops. So in 
 you're going to need to install some "unusual" libraries for things like C/C++ (libxml2), Objective-C
 (GNUStep), and C# (Mono).
 
+You need Java JDK 7 to build Enunciate. Currently, it doesn't build with Java JDK 8. Make sure Maven is
+using Java JDK 7 by setting JAVA_HOME before running Maven:
+
+    export JAVA_HOME=/PATH/TO/JDK/7
+    mvn clean install
+
 ### Ubuntu ###
 
 Here are the packages you'll need to install to run the full build on Ubuntu:
 
-```sudo apt-get install libxml2-dev mono-gmcs gnustep gnustep-devel ruby rubygems ruby-dev php5```
+```sudo apt-get install libxml2-dev mono-gmcs gnustep gnustep-devel ruby rubygems ruby-dev php5 openjdk-7-jdk```
 
 And then install the ruby json gem:
 

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,11 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.4</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
         <executions>
           <execution>


### PR DESCRIPTION
Fix for https://github.com/stoicflame/enunciate/issues/328
- Force version 1.4 of maven-antrun-plugin as there is no pom for default version 1.3 available.
- Update compile instructions to highlight that JDK 7 must be used.