### PR TITLE
Pull request for Jackson support for XmlElementWrapper annotation and enhanced sorting.

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/EnunciateConfiguration.java
+++ b/core/src/main/java/com/webcohesion/enunciate/EnunciateConfiguration.java
@@ -16,8 +16,14 @@ import java.util.*;
  */
 public class EnunciateConfiguration {
 
+  public enum PathSortStrategy {
+    breadth_first,
+    depth_first
+  }
+
   private String defaultSlug = "api";
   private String defaultVersion = null;
+  private PathSortStrategy defaultSortStrategy = PathSortStrategy.breadth_first;
   private String defaultTitle = "Web Service API";
   private String defaultDescription = null;
   private String defaultCopyright = null;
@@ -75,6 +81,16 @@ public class EnunciateConfiguration {
 
   public void setDefaultVersion(String defaultVersion) {
     this.defaultVersion = defaultVersion;
+  }
+
+  public PathSortStrategy getPathSortStrategy()  {
+    PathSortStrategy strategy = defaultSortStrategy;
+    try {
+      strategy = PathSortStrategy.valueOf(this.source.getString("[@path-sort-strategy]", this.defaultSortStrategy.name()));
+    } catch (IllegalArgumentException e) {
+      // Ignore?  Log?
+    }
+    return strategy;
   }
 
   public String getTitle() {

--- a/core/src/main/java/com/webcohesion/enunciate/util/BreadthFirstResourcePathComparator.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/BreadthFirstResourcePathComparator.java
@@ -5,7 +5,7 @@ import java.util.Comparator;
 /**
  * @author Ryan Heaton
  */
-public class ResourcePathComparator implements Comparator<String> {
+public class BreadthFirstResourcePathComparator implements Comparator<String> {
 
   public int compare(String resource1Path, String resource2Path) {
     String[] path1Segments = resource1Path.split("/");

--- a/core/src/main/java/com/webcohesion/enunciate/util/DepthFirstResourcePathComparator.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/DepthFirstResourcePathComparator.java
@@ -1,0 +1,28 @@
+package com.webcohesion.enunciate.util;
+
+import java.util.Comparator;
+
+/**
+ * @author Ryan Heaton
+ */
+public class DepthFirstResourcePathComparator implements Comparator<String> {
+
+  public int compare(String resource1Path, String resource2Path) {
+    String[] path1Segments = resource1Path.split("/");
+    String[] path2Segments = resource2Path.split("/");
+    int index = 0;
+    int comparison = 0;
+    while ((index<path1Segments.length || index<path2Segments.length) && comparison==0) {
+      if (index>=path1Segments.length || index>=path2Segments.length) {
+        comparison = path1Segments.length - path2Segments.length;
+      } else {
+        String subpath1 = path1Segments[index];
+        String subpath2 = path2Segments[index];
+        comparison = subpath1.compareTo(subpath2);
+        index++;
+      }
+    }
+
+    return comparison;
+  }
+}

--- a/core/src/main/java/com/webcohesion/enunciate/util/PathSummaryComparator.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/PathSummaryComparator.java
@@ -1,0 +1,27 @@
+package com.webcohesion.enunciate.util;
+
+import com.webcohesion.enunciate.EnunciateConfiguration;
+import com.webcohesion.enunciate.api.PathSummary;
+
+import java.util.Comparator;
+
+/**
+ * @author Ryan Heaton
+ */
+public class PathSummaryComparator implements Comparator<PathSummary> {
+
+    private final Comparator<String> pathComparator;
+
+    public PathSummaryComparator(EnunciateConfiguration.PathSortStrategy strategy) {
+        if (strategy== EnunciateConfiguration.PathSortStrategy.breadth_first) {
+            pathComparator = new BreadthFirstResourcePathComparator();
+        } else {
+            pathComparator = new DepthFirstResourcePathComparator();
+        }
+    }
+
+    @Override
+    public int compare(PathSummary p1, PathSummary p2) {
+        return pathComparator.compare(p1.getPath(), p2.getPath());
+    }
+}

--- a/core/src/main/java/com/webcohesion/enunciate/util/ResourceComparator.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/ResourceComparator.java
@@ -1,0 +1,38 @@
+package com.webcohesion.enunciate.util;
+
+import com.webcohesion.enunciate.EnunciateConfiguration;
+import com.webcohesion.enunciate.api.resources.Method;
+import com.webcohesion.enunciate.api.resources.Resource;
+import com.webcohesion.enunciate.api.resources.ResourceGroup;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * @author Ryan Heaton
+ */
+public class ResourceComparator implements Comparator<Resource> {
+
+    private final Comparator<String> pathComparator;
+
+    public ResourceComparator(EnunciateConfiguration.PathSortStrategy strategy) {
+        if (strategy== EnunciateConfiguration.PathSortStrategy.breadth_first) {
+            pathComparator = new BreadthFirstResourcePathComparator();
+        } else {
+            pathComparator = new DepthFirstResourcePathComparator();
+        }
+    }
+
+    @Override
+    public int compare(Resource g1, Resource g2) {
+        int compare = pathComparator.compare(g1.getPath(), g2.getPath());
+        if (compare==0) {
+            List<? extends Method> m1 = g1.getMethods();
+            List<? extends Method> m2 = g2.getMethods();
+            if (m1.size()==1 && m2.size()==1) {
+                compare = (m1.get(0).getHttpMethod().compareTo(m2.get(0).getHttpMethod()));
+            }
+        }
+        return compare;
+    }
+}

--- a/core/src/main/java/com/webcohesion/enunciate/util/ResourceGroupComparator.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/ResourceGroupComparator.java
@@ -1,5 +1,6 @@
 package com.webcohesion.enunciate.util;
 
+import com.webcohesion.enunciate.EnunciateConfiguration;
 import com.webcohesion.enunciate.api.resources.ResourceGroup;
 
 import java.util.Comparator;
@@ -9,7 +10,15 @@ import java.util.Comparator;
  */
 public class ResourceGroupComparator implements Comparator<ResourceGroup> {
 
-  private final ResourcePathComparator pathComparator = new ResourcePathComparator();
+  private final Comparator<String> pathComparator;
+
+  public ResourceGroupComparator(EnunciateConfiguration.PathSortStrategy strategy) {
+    if (strategy== EnunciateConfiguration.PathSortStrategy.breadth_first) {
+      pathComparator = new BreadthFirstResourcePathComparator();
+    } else {
+      pathComparator = new DepthFirstResourcePathComparator();
+    }
+  }
 
   @Override
   public int compare(ResourceGroup g1, ResourceGroup g2) {

--- a/core/src/main/java/com/webcohesion/enunciate/util/SortedList.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/SortedList.java
@@ -1,0 +1,28 @@
+package com.webcohesion.enunciate.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+
+public class SortedList<T> extends ArrayList<T> {
+    private Comparator<T> comparator;
+
+    public SortedList(Comparator<T> comparator) {
+        this.comparator = comparator;
+    }
+
+    @Override
+    public boolean add(T t) {
+        int index = Collections.binarySearch(this, t, comparator);
+        if (index<0) {
+            index = -index - 1;
+        }
+        if (index>=size()) {
+            super.add(t);
+        } else {
+            super.add(index, t);
+        }
+        return true;
+    }
+}
+

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/Member.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/Member.java
@@ -219,6 +219,11 @@ public class Member extends Accessor {
       if (elementInfo != null && !"##default".equals(elementInfo.name())) {
         propertyName = elementInfo.name();
       }
+
+      XmlElementWrapper elementWrapperInfo = getAnnotation(XmlElementWrapper.class);
+      if (elementWrapperInfo != null && !"##default".equals(elementWrapperInfo.name())) {
+        propertyName = elementWrapperInfo.name();
+      }
     }
 
     if ((propertyInfo != null) && (!"".equals(propertyInfo.value()))) {

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/Member.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/Member.java
@@ -217,6 +217,11 @@ public class Member extends Accessor {
       if (elementInfo != null && !"##default".equals(elementInfo.name())) {
         propertyName = elementInfo.name();
       }
+
+      XmlElementWrapper elementWrapperInfo = getAnnotation(XmlElementWrapper.class);
+      if (elementWrapperInfo != null && !"##default".equals(elementWrapperInfo.name())) {
+        propertyName = elementWrapperInfo.name();
+      }
     }
 
     if ((propertyInfo != null) && (!"".equals(propertyInfo.value()))) {

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/AnnotationBasedResourceGroupImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/AnnotationBasedResourceGroupImpl.java
@@ -1,9 +1,11 @@
 package com.webcohesion.enunciate.modules.jaxrs.api.impl;
 
+import com.webcohesion.enunciate.EnunciateConfiguration;
 import com.webcohesion.enunciate.api.PathSummary;
 import com.webcohesion.enunciate.api.resources.Method;
 import com.webcohesion.enunciate.api.resources.Resource;
 import com.webcohesion.enunciate.api.resources.ResourceGroup;
+import com.webcohesion.enunciate.util.PathSummaryComparator;
 
 import javax.lang.model.element.AnnotationMirror;
 import java.util.*;
@@ -16,11 +18,14 @@ public class AnnotationBasedResourceGroupImpl implements ResourceGroup {
   private final String contextPath;
   private final String label;
   private final List<Resource> resources;
+  private final EnunciateConfiguration.PathSortStrategy sortStrategy;
 
-  public AnnotationBasedResourceGroupImpl(String contextPath, String label, List<Resource> resources) {
+  public AnnotationBasedResourceGroupImpl(String contextPath, String label, List<Resource> resources,
+                                          EnunciateConfiguration.PathSortStrategy sortStrategy) {
     this.contextPath = contextPath;
     this.label = label;
     this.resources = resources;
+    this.sortStrategy = sortStrategy;
   }
 
   @Override
@@ -87,7 +92,9 @@ public class AnnotationBasedResourceGroupImpl implements ResourceGroup {
         pathSummary.getMethods().add(method.getHttpMethod());
       }
     }
-    return new ArrayList<PathSummary>(paths.values());
+    ArrayList<PathSummary> pathSummaries = new ArrayList<PathSummary>(paths.values());
+    Collections.sort(pathSummaries, new PathSummaryComparator(sortStrategy));
+    return pathSummaries;
   }
 
   @Override

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ResourceClassResourceGroupImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ResourceClassResourceGroupImpl.java
@@ -9,6 +9,7 @@ import com.webcohesion.enunciate.javac.decorations.element.ElementUtils;
 import com.webcohesion.enunciate.metadata.Label;
 import com.webcohesion.enunciate.metadata.rs.ResourceLabel;
 import com.webcohesion.enunciate.modules.jaxrs.model.ResourceMethod;
+import com.webcohesion.enunciate.util.PathSummaryComparator;
 
 import javax.lang.model.element.AnnotationMirror;
 import java.util.*;
@@ -98,7 +99,9 @@ public class ResourceClassResourceGroupImpl implements ResourceGroup {
         summary.getMethods().addAll(methods);
       }
     }
-    return new ArrayList<PathSummary>(summaries.values());
+    ArrayList<PathSummary> pathSummaries = new ArrayList<PathSummary>(summaries.values());
+    Collections.sort(pathSummaries, new PathSummaryComparator(resourceClass.getContext().getContext().getConfiguration().getPathSortStrategy()));
+    return pathSummaries;
   }
 
   @Override

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/EnunciateSpringWebContext.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/EnunciateSpringWebContext.java
@@ -1,5 +1,6 @@
 package com.webcohesion.enunciate.modules.spring_web;
 
+import com.webcohesion.enunciate.EnunciateConfiguration;
 import com.webcohesion.enunciate.EnunciateContext;
 import com.webcohesion.enunciate.api.InterfaceDescriptionFile;
 import com.webcohesion.enunciate.api.resources.Resource;
@@ -14,7 +15,9 @@ import com.webcohesion.enunciate.modules.spring_web.api.impl.ResourceClassResour
 import com.webcohesion.enunciate.modules.spring_web.api.impl.ResourceImpl;
 import com.webcohesion.enunciate.modules.spring_web.model.RequestMapping;
 import com.webcohesion.enunciate.modules.spring_web.model.SpringController;
+import com.webcohesion.enunciate.util.ResourceComparator;
 import com.webcohesion.enunciate.util.ResourceGroupComparator;
+import com.webcohesion.enunciate.util.SortedList;
 
 import java.util.*;
 
@@ -114,7 +117,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext implements
       }
     }
 
-    Collections.sort(resourceGroups, new ResourceGroupComparator());
+    Collections.sort(resourceGroups, new ResourceGroupComparator(context.getConfiguration().getPathSortStrategy()));
 
     return resourceGroups;
   }
@@ -139,7 +142,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext implements
     }
 
     ArrayList<ResourceGroup> resourceGroups = new ArrayList<ResourceGroup>(resourcesByPath.values());
-    Collections.sort(resourceGroups, new ResourceGroupComparator());
+    Collections.sort(resourceGroups, new ResourceGroupComparator(context.getConfiguration().getPathSortStrategy()));
     return resourceGroups;
   }
 
@@ -147,6 +150,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext implements
     Map<String, AnnotationBasedResourceGroupImpl> resourcesByAnnotation = new HashMap<String, AnnotationBasedResourceGroupImpl>();
 
     FacetFilter facetFilter = context.getConfiguration().getFacetFilter();
+    EnunciateConfiguration.PathSortStrategy pathSortStrategy = context.getConfiguration().getPathSortStrategy();
     for (SpringController springController : controllers) {
       for (RequestMapping method : springController.getRequestMappings()) {
         if (facetFilter.accept(method)) {
@@ -154,7 +158,9 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext implements
           String label = annotation == null ? "Other" : annotation.value();
           AnnotationBasedResourceGroupImpl resourceGroup = resourcesByAnnotation.get(label);
           if (resourceGroup == null) {
-            resourceGroup = new AnnotationBasedResourceGroupImpl(relativeContextPath, label, new ArrayList<Resource>());
+            resourceGroup = new AnnotationBasedResourceGroupImpl(relativeContextPath, label,
+                    new SortedList<Resource>(new ResourceComparator(pathSortStrategy)),
+                    context.getConfiguration().getPathSortStrategy());
             resourcesByAnnotation.put(label, resourceGroup);
           }
 
@@ -164,7 +170,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext implements
     }
 
     ArrayList<ResourceGroup> resourceGroups = new ArrayList<ResourceGroup>(resourcesByAnnotation.values());
-    Collections.sort(resourceGroups, new ResourceGroupComparator());
+    Collections.sort(resourceGroups, new ResourceGroupComparator(context.getConfiguration().getPathSortStrategy()));
     return resourceGroups;
   }
 }

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/AnnotationBasedResourceGroupImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/AnnotationBasedResourceGroupImpl.java
@@ -1,9 +1,11 @@
 package com.webcohesion.enunciate.modules.spring_web.api.impl;
 
+import com.webcohesion.enunciate.EnunciateConfiguration;
 import com.webcohesion.enunciate.api.PathSummary;
 import com.webcohesion.enunciate.api.resources.Method;
 import com.webcohesion.enunciate.api.resources.Resource;
 import com.webcohesion.enunciate.api.resources.ResourceGroup;
+import com.webcohesion.enunciate.util.PathSummaryComparator;
 
 import javax.lang.model.element.AnnotationMirror;
 import java.util.*;
@@ -16,11 +18,14 @@ public class AnnotationBasedResourceGroupImpl implements ResourceGroup {
   private final String contextPath;
   private final String label;
   private final List<Resource> resources;
+  private final EnunciateConfiguration.PathSortStrategy sortStrategy;
 
-  public AnnotationBasedResourceGroupImpl(String contextPath, String label, List<Resource> resources) {
+  public AnnotationBasedResourceGroupImpl(String contextPath, String label, List<Resource> resources,
+                                          EnunciateConfiguration.PathSortStrategy sortStrategy) {
     this.contextPath = contextPath;
     this.label = label;
     this.resources = resources;
+    this.sortStrategy = sortStrategy;
   }
 
   @Override
@@ -87,7 +92,9 @@ public class AnnotationBasedResourceGroupImpl implements ResourceGroup {
         pathSummary.getMethods().add(method.getHttpMethod());
       }
     }
-    return new ArrayList<PathSummary>(paths.values());
+    ArrayList<PathSummary> pathSummaries = new ArrayList<PathSummary>(paths.values());
+    Collections.sort(pathSummaries, new PathSummaryComparator(sortStrategy));
+    return pathSummaries;
   }
 
   @Override

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ResourceClassResourceGroupImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ResourceClassResourceGroupImpl.java
@@ -10,6 +10,7 @@ import com.webcohesion.enunciate.metadata.Label;
 import com.webcohesion.enunciate.metadata.rs.ResourceLabel;
 import com.webcohesion.enunciate.modules.spring_web.model.RequestMapping;
 import com.webcohesion.enunciate.modules.spring_web.model.SpringController;
+import com.webcohesion.enunciate.util.PathSummaryComparator;
 
 import javax.lang.model.element.AnnotationMirror;
 import java.util.*;
@@ -99,7 +100,9 @@ public class ResourceClassResourceGroupImpl implements ResourceGroup {
         summary.getMethods().addAll(methods);
       }
     }
-    return new ArrayList<PathSummary>(summaries.values());
+    ArrayList<PathSummary> pathSummaries = new ArrayList<PathSummary>(summaries.values());
+    Collections.sort(pathSummaries, new PathSummaryComparator(controllerClass.getContext().getContext().getConfiguration().getPathSortStrategy()));
+    return pathSummaries;
   }
 
   @Override

--- a/top/src/main/resources/META-INF/enunciate-2.3.0.xsd
+++ b/top/src/main/resources/META-INF/enunciate-2.3.0.xsd
@@ -93,6 +93,25 @@
           <xs:documentation>A version for this API.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="path-sort-strategy" type="xs:string" default="breadth_first">
+        <xs:annotation>
+          <xs:documentation>The strategy to use when sorting paths.</xs:documentation>
+        </xs:annotation>
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="breadth_first">
+              <xs:annotation>
+                <xs:documentation>Paths are split into components ("/teams/{id}/players" -> ["teams","{id}","players"]) and sorted first by the number of components. For example: ["/teams","/users","/teams/{id}","/users/{id}","/teams/{id}/players"]</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="depth_first">
+              <xs:annotation>
+                <xs:documentation>Paths are split into components ("/teams/{id}/players" -> ["teams","{id}","players"]) and sorted first by the first component, then the second, and so on.  For example: ["/teams","/teams/{id}","/teams/{id}/players","/users","/users/{id}"]</xs:documentation>
+              </xs:annotation>
+            </xs:enumeration>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 


### PR DESCRIPTION
1) Added support for javax.xml.bind.annotation.XmlElementWrapper in jackson and jackson1 (Member.java).
2) Sort the list of PathSummary objects in annotation-based and class based resource groups.
3) Added config option to specify how to sort paths. I called the two different options "breadth-first" and "depth-first". Probably not the greatest names, but that's the best I could come up with. The current sorting strategy orders paths by number of components first (this what I called breadth-first):

a
b
c
a/a
a/b
b/a
a/a/a
The strategy I'm proposing (depth-first) sorts the same set of paths like this:

a
a/a
a/a/a
a/b
b
b/a
c

4) Sort Resources in AnnotationBasedResourceGroupImpl by path and method so they are sorted in the generated resource_*.html file.