### PR TITLE
create a link to swagger that works better when the app isn't deployed.

### DIFF
--- a/swagger/swagger-ui/index.html
+++ b/swagger/swagger-ui/index.html
@@ -35,6 +35,9 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       }
+      else if (document.location.href.substring(0, 5) === "file:") {
+        url = "../swagger.json";
+      }
       else {
         var baseUrl = document.location.href;
         //this removes the anchor at the end, if there is one


### PR DESCRIPTION
this patch vastly improves the behavior of the swagger link if you are browsing the built website in your local maven target folder.

https://github.com/stoicflame/enunciate/issues/164