### PR TITLE
Reduce the cdn domains used

### DIFF
--- a/docs/src/main/resources/com/webcohesion/enunciate/modules/docs/docs.fmt
+++ b/docs/src/main/resources/com/webcohesion/enunciate/modules/docs/docs.fmt
@@ -137,7 +137,7 @@
 
 
   <!-- JavaScript placed at the end of the document so the pages load faster. -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 
   <!-- Bootstrap core JavaScript
   ================================================== -->

--- a/docs/template/home.html
+++ b/docs/template/home.html
@@ -290,7 +290,7 @@
 
 
   <!-- JavaScript placed at the end of the document so the pages load faster. -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 
   <!-- Bootstrap core JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>

--- a/docs/template/resource.html
+++ b/docs/template/resource.html
@@ -460,7 +460,7 @@
 
 
   <!-- JavaScript placed at the end of the document so the pages load faster. -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 
   <!-- Bootstrap core JavaScript
   ================================================== -->

--- a/docs/template/template.html
+++ b/docs/template/template.html
@@ -287,7 +287,7 @@
 
 
   <!-- JavaScript placed at the end of the document so the pages load faster. -->
-  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
 
   <!-- Bootstrap core JavaScript
   ================================================== -->


### PR DESCRIPTION
Several cdn's are used by enunciate. If we want to display the apidocs directly from jenkins (using the mvn generated site) some content security restrictions prevent the generated documentation to display correctly. Newer versions of jeninks have a very restrictive default set of permissions. See https://wiki.jenkins-ci.org/display/JENKINS/Configuring+Content+Security+Policy.

We can add the domains which can be used to contain external css and javascript files. To limit the domains we have to allow in Jenkins to (cdnjs.cloudflare.com and maxcdn.bootstrapcdn.com for modern browsers) I've changed the domain from ajax.googleapis.com to cdnjs.cloudflare.com

