### PR TITLE
Explicit namespace mapping overrides auto-generated default namespace

### DIFF
--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/NamespacePropertiesArtifact.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/NamespacePropertiesArtifact.java
@@ -81,7 +81,7 @@ public class NamespacePropertiesArtifact extends BaseArtifact {
         }
       }
 
-      if (schemaWithTheMostTypes != null) {
+      if (schemaWithTheMostTypes != null && !properties.containsValue(schemaWithTheMostTypes.getNamespace())) {
         defaultNs = schemaWithTheMostTypes.getNamespace();
       }
     }


### PR DESCRIPTION
If an explicit namespace mapping is specified in the Enunciate XML config, it will prevent an auto-generated default mapping for the same namespace from being applied. See https://github.com/stoicflame/enunciate/issues/498