### PR TITLE
Initial support for Lombok annotations

### DIFF
--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/DecoratedTypeElement.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/DecoratedTypeElement.java
@@ -17,6 +17,7 @@ package com.webcohesion.enunciate.javac.decorations.element;
 
 import com.webcohesion.enunciate.javac.decorations.ElementDecorator;
 import com.webcohesion.enunciate.javac.decorations.TypeMirrorDecorator;
+import com.webcohesion.enunciate.javac.decorations.lombok.LombokMethodGenerator;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
@@ -95,9 +96,23 @@ public class DecoratedTypeElement extends DecoratedElement<TypeElement> implemen
   public List<? extends ExecutableElement> getMethods() {
     if (this.methods == null) {
       this.methods = ElementDecorator.decorate(ElementFilter.methodsIn(this.delegate.getEnclosedElements()), this.env);
+      LombokMethodGenerator lombokMethodGenerator = new LombokMethodGenerator(this.delegate.getAnnotationMirrors(), this.methods, getFields(), this.env);
+      lombokMethodGenerator.generateLombokGettersAndSetters();
     }
 
     return this.methods;
+  }
+
+  public List<? extends VariableElement> getFields() {
+    List<VariableElement> fields = new ArrayList<VariableElement>();
+    List<VariableElement> allFields = ElementFilter.fieldsIn(this.delegate.getEnclosedElements());
+    for (VariableElement field : allFields) {
+      if (field.getKind() == ElementKind.FIELD && !(field.getModifiers().contains(Modifier.STATIC))) {
+        fields.add(field);
+      }
+    }
+
+    return fields;
   }
 
   public List<ExecutableElement> getConstructors() {

--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/lombok/LombokMethodGenerator.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/lombok/LombokMethodGenerator.java
@@ -1,0 +1,92 @@
+package com.webcohesion.enunciate.javac.decorations.lombok;
+
+import com.webcohesion.enunciate.javac.decorations.element.DecoratedExecutableElement;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.*;
+import java.util.List;
+
+/**
+ * @author Tomasz Kalkosiński
+ */
+public class LombokMethodGenerator {
+    private static final String LOMBOK_DATA_FQN = "lombok.Data";
+    private static final String LOMBOK_GETTER_FQN = "lombok.Getter";
+    private static final String LOMBOK_SETTER_FQN = "lombok.Setter";
+
+    private List<? extends AnnotationMirror> annotationMirrors;
+    private List<ExecutableElement> methods;
+    private List<? extends VariableElement> fields;
+    private ProcessingEnvironment env;
+
+    public LombokMethodGenerator(List<? extends AnnotationMirror> annotationMirrors, List<ExecutableElement> methods, List<? extends VariableElement> fields, ProcessingEnvironment env) {
+        this.annotationMirrors = annotationMirrors;
+        this.methods = methods;
+        this.fields = fields;
+        this.env = env;
+    }
+
+    public void generateLombokGettersAndSetters() {
+        for (VariableElement field : fields) {
+            if (shouldGenerateGetter(field)) {
+                methods.add(new LombokPropertyDecoratedExecutableElement(field, env, true));
+            }
+            if (shouldGenerateSetter(field)) {
+                methods.add(new LombokPropertyDecoratedExecutableElement(field, env, false));
+            }
+        }
+    }
+
+    private boolean shouldGenerateGetter(VariableElement field) {
+        String fieldSimpleName = field.getSimpleName().toString();
+        for (ExecutableElement method : methods) {
+            DecoratedExecutableElement decoratedMethod = (DecoratedExecutableElement) method;
+            if (decoratedMethod.getPropertyName() != null && decoratedMethod.getPropertyName().equals(fieldSimpleName) && decoratedMethod.isGetter()) {
+                return false;
+            }
+        }
+
+        if (isAnnotated(field.getAnnotationMirrors(), LOMBOK_GETTER_FQN)) {
+            return true;
+        }
+
+        if (isAnnotated(annotationMirrors, LOMBOK_DATA_FQN)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean shouldGenerateSetter(VariableElement field) {
+        String fieldSimpleName = field.getSimpleName().toString();
+        for (ExecutableElement method : methods) {
+            DecoratedExecutableElement decoratedMethod = (DecoratedExecutableElement) method;
+            if (decoratedMethod.getPropertyName() != null && decoratedMethod.getPropertyName().equals(fieldSimpleName) && decoratedMethod.isSetter()) {
+                return false;
+            }
+        }
+
+        if (isAnnotated(field.getAnnotationMirrors(), LOMBOK_SETTER_FQN)) {
+            return true;
+        }
+
+        if (isAnnotated(annotationMirrors, LOMBOK_DATA_FQN)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean isAnnotated(List<? extends AnnotationMirror> annotationMirrors, String expectedAnnotationFqn) {
+        for (AnnotationMirror annotationMirror : annotationMirrors) {
+            Element annotationDeclaration = annotationMirror.getAnnotationType().asElement();
+            if (annotationDeclaration != null) {
+                String fqn = annotationDeclaration instanceof TypeElement ? ((TypeElement) annotationDeclaration).getQualifiedName().toString() : "";
+                if (fqn.equals(expectedAnnotationFqn)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/lombok/LombokPropertyDecoratedExecutableElement.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/lombok/LombokPropertyDecoratedExecutableElement.java
@@ -1,0 +1,122 @@
+package com.webcohesion.enunciate.javac.decorations.lombok;
+
+import com.webcohesion.enunciate.javac.decorations.element.DecoratedExecutableElement;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.*;
+import javax.lang.model.type.TypeMirror;
+import java.lang.annotation.Annotation;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @author Tomasz Kalkosiński
+ */
+public class LombokPropertyDecoratedExecutableElement extends DecoratedExecutableElement {
+
+    private VariableElement variableElement;
+    private boolean getter;
+
+    public LombokPropertyDecoratedExecutableElement(VariableElement variableElement, ProcessingEnvironment env, boolean getter) {
+        super(null, env);
+        this.variableElement = variableElement;
+        this.getter = getter;
+    }
+
+    @Override
+    public List<? extends TypeParameterElement> getTypeParameters() {
+        return null;
+    }
+
+    @Override
+    public TypeMirror getReturnType() {
+        return getter ? variableElement.asType() : null;
+    }
+
+    @Override
+    public List<? extends VariableElement> getParameters() {
+        return getter ? Collections.<VariableElement>emptyList() : Collections.singletonList(variableElement);
+    }
+
+    @Override
+    public boolean isVarArgs() {
+        return false;
+    }
+
+    @Override
+    public List<? extends TypeMirror> getThrownTypes() {
+        return null;
+    }
+
+    @Override
+    public AnnotationValue getDefaultValue() {
+        return null;
+    }
+
+    @Override
+    public TypeMirror asType() {
+        return variableElement.asType();
+    }
+
+    @Override
+    public ElementKind getKind() {
+        return variableElement.getKind();
+    }
+
+    @Override
+    public List<? extends AnnotationMirror> getAnnotationMirrors() {
+        return variableElement.getAnnotationMirrors();
+    }
+
+    @Override
+    public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+        return variableElement.getAnnotation(annotationType);
+    }
+
+    @Override
+    public Set<Modifier> getModifiers() {
+        HashSet<Modifier> clone = new HashSet<Modifier>(variableElement.getModifiers());
+        if (clone.contains(Modifier.PRIVATE)) {
+            clone.remove(Modifier.PRIVATE);
+            clone.add(Modifier.PUBLIC);
+        }
+        return clone;
+    }
+
+    @Override
+    public Name getSimpleName() {
+        return variableElement.getSimpleName();
+    }
+
+    @Override
+    public Element getEnclosingElement() {
+        return variableElement.getEnclosingElement();
+    }
+
+    @Override
+    public List<? extends Element> getEnclosedElements() {
+        return variableElement.getEnclosedElements();
+    }
+
+    @Override
+    public String getPropertyName() {
+        return variableElement.getSimpleName().toString();
+    }
+
+    @Override
+    public String toString() {
+        return variableElement.toString();
+    }
+
+    @Override
+    public boolean isGetter() {
+        return getter;
+    }
+
+    @Override
+    public boolean isSetter() {
+        return !getter;
+    }
+}


### PR DESCRIPTION
I've followed Lombok implementation for IntelliJ IDEA plugin. This plugin generates missing getters and setters on thy fly based on source code analysis and Lombok annotations. These mehods are not visible in the source code, but they are available for code completion, navigation, searching etc. IDEA sees these methods as present, beacuse they're present in PsiClass - their AST representation of a source code you work on.

For enunciate I propose to do the same. At the moment of getting original methods from Java source code I check if Lombok annotations are present and generate missing ones. I create fake DecoratedExecutableElements that behave like a real getters and setters.

I have a doubt about tests. Do you expect any? I've tested manually and it was fine.

I couldn't build mvn clean install, because JBoss example was failing, I only succeeded with skipping tests.