### PR TITLE
#487 fix: removed double wrapping of arrays

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.webcohesion.enunciate.javac.decorations.Annotations;
 import com.webcohesion.enunciate.javac.decorations.DecoratedProcessingEnvironment;
-import com.webcohesion.enunciate.javac.decorations.ElementDecorator;
 import com.webcohesion.enunciate.javac.decorations.TypeMirrorDecorator;
 import com.webcohesion.enunciate.javac.decorations.type.DecoratedTypeMirror;
 import com.webcohesion.enunciate.metadata.rs.TypeHint;
@@ -175,7 +174,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
 
   @Override
   public JsonType visitArray(ArrayType arrayType, Context context) {
-    return new JsonArrayType(arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack)));
+    return arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack));
   }
 
   @Override

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/types/JsonTypeVisitor.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/types/JsonTypeVisitor.java
@@ -173,7 +173,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
 
   @Override
   public JsonType visitArray(ArrayType arrayType, Context context) {
-    return new JsonArrayType(arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack)));
+    return arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack));
   }
 
   @Override


### PR DESCRIPTION
I'm new to this code, so I explain this simple fix in details.

The problem (in classes JsonTypeVisitor of both jackson modules):
Arrays are wrapped with JsonArrayType twice 
In visitArray method:
```
return new JsonArrayType(arrayType.getComponentType().accept(this, 
     new Context(context.context, true, false, context.stack)));
```
and in all other methods:
```
return context.isInArray() || context.isInCollection() ? 
     new JsonArrayType(jsonType) 
     : jsonType;
```

Thus the problem comes from visitArray method which does the both: passes on the context in "in-array" state, and wraps the result. 