### PR TITLE
Enunciate 487 (generic collections)

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
@@ -133,7 +133,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
           DecoratedProcessingEnvironment env = context.getContext().getContext().getProcessingEnvironment();
           TypeMirror componentType = getComponentType((DecoratedTypeMirror) TypeMirrorDecorator.decorate(declaredType, env), env);
           if (componentType != null) {
-            return new JsonArrayType(componentType.accept(this, new Context(context.context, false, true, context.stack)));
+            return componentType.accept(this, new Context(context.context, false, true, context.stack));
           }
           else {
             switch (declaredElement.getKind()) {

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.webcohesion.enunciate.javac.decorations.Annotations;
 import com.webcohesion.enunciate.javac.decorations.DecoratedProcessingEnvironment;
-import com.webcohesion.enunciate.javac.decorations.ElementDecorator;
 import com.webcohesion.enunciate.javac.decorations.TypeMirrorDecorator;
 import com.webcohesion.enunciate.javac.decorations.type.DecoratedTypeMirror;
 import com.webcohesion.enunciate.metadata.rs.TypeHint;
@@ -175,7 +174,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
 
   @Override
   public JsonType visitArray(ArrayType arrayType, Context context) {
-    return new JsonArrayType(arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack)));
+    return arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack));
   }
 
   @Override

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/types/JsonTypeVisitor.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/types/JsonTypeVisitor.java
@@ -132,7 +132,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
           DecoratedProcessingEnvironment env = context.getContext().getContext().getProcessingEnvironment();
           TypeMirror componentType = getComponentType((DecoratedTypeMirror) TypeMirrorDecorator.decorate(declaredType, env), env);
           if (componentType != null) {
-            return new JsonArrayType(componentType.accept(this, new Context(context.context, false, true, context.stack)));
+            return componentType.accept(this, new Context(context.context, false, true, context.stack));
           }
           else {
             switch (declaredElement.getKind()) {

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/types/JsonTypeVisitor.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/types/JsonTypeVisitor.java
@@ -173,7 +173,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
 
   @Override
   public JsonType visitArray(ArrayType arrayType, Context context) {
-    return new JsonArrayType(arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack)));
+    return arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack));
   }
 
   @Override


### PR DESCRIPTION
The same as the previous #487 fix, now it fixes generic collections.
The following example still leads to "array of array" bug.
```
@POST
public Response process(List<Persona> list) { ... }
```

This fix is less critical, since the problem can be worked around with `@TypeHint(Persona[].class)` annotation.