### PR TITLE
Fix infinite loop in EnunciateConfiguration

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/EnunciateConfiguration.java
+++ b/core/src/main/java/com/webcohesion/enunciate/EnunciateConfiguration.java
@@ -232,11 +232,12 @@ public class EnunciateConfiguration {
       FileReader reader = new FileReader(file);
       StringWriter writer = new StringWriter();
       char[] chars = new char[100];
-      int read = reader.read(chars) ;
-      while (read >= 0) {
+      int read = -1;
+      while ((read = reader.read(chars)) >= 0) {
         writer.write(chars, 0, read);
       }
       reader.close();
+      writer.flush();
       writer.close();
       return writer.toString();
     }


### PR DESCRIPTION
Fixing an infinite loop when writing read chars into the StringWriter

Raised as issue #535 