### PR TITLE
Java8 Date/Time support for jackson1 module.

### DIFF
--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
@@ -266,6 +266,21 @@ public class EnunciateJackson1Context extends EnunciateModuleContext implements 
     knownTypes.put(POJONode.class.getName(), KnownJsonType.OBJECT);
     knownTypes.put(BooleanNode.class.getName(), KnownJsonType.BOOLEAN);
     knownTypes.put(Class.class.getName(), KnownJsonType.OBJECT);
+
+    knownTypes.put("java.time.Period", KnownJsonType.STRING);
+    knownTypes.put("java.time.Duration", this.dateType);
+    knownTypes.put("java.time.Instant", this.dateType);
+    knownTypes.put("java.time.Year", this.dateType);
+    knownTypes.put("java.time.YearMonth", KnownJsonType.STRING);
+    knownTypes.put("java.time.MonthDay", KnownJsonType.STRING);
+    knownTypes.put("java.time.ZoneId", KnownJsonType.STRING);
+    knownTypes.put("java.time.ZoneOffset", KnownJsonType.STRING);
+    knownTypes.put("java.time.LocalDate", KnownJsonType.STRING);
+    knownTypes.put("java.time.LocalTime", KnownJsonType.STRING);
+    knownTypes.put("java.time.LocalDateTime", KnownJsonType.STRING);
+    knownTypes.put("java.time.OffsetTime", KnownJsonType.STRING);
+    knownTypes.put("java.time.ZonedDateTime", this.dateType);
+    knownTypes.put("java.time.OffsetDateTime", this.dateType);
     knownTypes.put("org.joda.time.DateTime", this.dateType);
 
     return knownTypes;


### PR DESCRIPTION
Since Issue #271 fixed by c7c424a15397fa, the jackson module supports Java8 Date/Time classes.
I'm backporting relevant codelines to jackson1 module.

I know jackson1 is deprecated but I can't upgrade to version 2 because version 1.9.11 is provided by Red Hat EAP 6.

With this change I am able to generate proper documentation and examples for my services.

Thank you,

Loïc