### PR TITLE
Json type info page : add link to subtypes. Fixes #557.

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/api/datatype/DataType.java
+++ b/core/src/main/java/com/webcohesion/enunciate/api/datatype/DataType.java
@@ -44,9 +44,13 @@ public interface DataType extends HasStyles, HasAnnotations, HasFacets {
 
   List<DataTypeReference> getSupertypes();
 
+  List<DataTypeReference> getSubtypes();
+
   String getSince();
 
   String getVersion();
+
+  boolean isAbstract();
 
   Example getExample();
 

--- a/docs/src/main/resources/com/webcohesion/enunciate/modules/docs/docs.fmt
+++ b/docs/src/main/resources/com/webcohesion/enunciate/modules/docs/docs.fmt
@@ -999,6 +999,16 @@ ${method.example.responseBody?xhtml}
         <dt>Version</dt>
         <dd>${type.version}</dd>
       [/#if]
+      [#if type.abstract]
+        <dt>Abstract type</dt><dd></dd>
+      [/#if]
+      [#if type.subtypes??]
+        <dt>Direct known subtypes</dt><dd>
+        [#list type.subtypes as subtype]
+          <a href="${subtype.slug}.html">${subtype.label}</a>
+        [/#list]
+        </dd>
+      [/#if]
       </dl>
       [#if type.values??]
 
@@ -1073,6 +1083,10 @@ ${method.example.responseBody?xhtml}
 
       <p class="lead">Example</p>
 
+      [#if type.abstract]
+        <div class="alert alert-warning">This data type is abstract. The example below may be incomplete. More accurate examples can be found in subtypes pages.</div>
+      [/#if]
+      
       <pre class="prettyprint language-${type.example.lang} example">${type.example.body?xhtml}</pre>
       [/#if]
     [/@boilerplate]

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/DataTypeImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/DataTypeImpl.java
@@ -94,6 +94,11 @@ public abstract class DataTypeImpl implements DataType {
   }
 
   @Override
+  public List<DataTypeReference> getSubtypes() {
+    return null;
+  }
+
+  @Override
   public String getSince() {
     JavaDoc.JavaDocTagList tags = this.typeDefinition.getJavaDoc().get("since");
     return tags == null ? null : tags.toString();
@@ -103,6 +108,11 @@ public abstract class DataTypeImpl implements DataType {
   public String getVersion() {
     JavaDoc.JavaDocTagList tags = this.typeDefinition.getJavaDoc().get("version");
     return tags == null ? null : tags.toString();
+  }
+
+  @Override
+  public boolean isAbstract() {
+    return this.typeDefinition.isAbstract();
   }
 
   @Override

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/ObjectDataTypeImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/ObjectDataTypeImpl.java
@@ -19,6 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.webcohesion.enunciate.api.datatype.BaseType;
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
@@ -28,8 +32,10 @@ import com.webcohesion.enunciate.api.datatype.Value;
 import com.webcohesion.enunciate.facets.FacetFilter;
 import com.webcohesion.enunciate.modules.jackson.model.Member;
 import com.webcohesion.enunciate.modules.jackson.model.ObjectTypeDefinition;
+import com.webcohesion.enunciate.modules.jackson.model.TypeDefinition;
 import com.webcohesion.enunciate.modules.jackson.model.types.JsonClassType;
 import com.webcohesion.enunciate.modules.jackson.model.types.JsonType;
+import com.webcohesion.enunciate.modules.jackson.model.types.JsonTypeFactory;
 
 /**
  * @author Ryan Heaton
@@ -111,6 +117,22 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
     }
 
     return supertypes;
+  }
+
+  @Override
+  public List<DataTypeReference> getSubtypes() {
+    ArrayList<DataTypeReference> subtypes = new ArrayList<DataTypeReference>();
+    String myClassName = this.typeDefinition.getQualifiedName().toString();
+
+    for (TypeDefinition td : this.typeDefinition.getContext().getTypeDefinitions()) {
+      if (td instanceof ObjectTypeDefinition) {
+        TypeMirror superclass = td.getSuperclass();
+        if (superclass instanceof DeclaredType && (((TypeElement) ((DeclaredType) superclass).asElement()).getQualifiedName().toString().equals(myClassName))) {
+          subtypes.add(new DataTypeReferenceImpl(JsonTypeFactory.getJsonType(td.asType(), this.typeDefinition.getContext())));
+        }
+      }
+    }
+    return subtypes.isEmpty() ? null : subtypes;
   }
 
   @Override

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/DataTypeImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/DataTypeImpl.java
@@ -94,6 +94,11 @@ public abstract class DataTypeImpl implements DataType {
   }
 
   @Override
+  public List<DataTypeReference> getSubtypes() {
+    return null;
+  }
+
+  @Override
   public String getSince() {
     JavaDoc.JavaDocTagList tags = this.typeDefinition.getJavaDoc().get("since");
     return tags == null ? null : tags.toString();
@@ -103,6 +108,11 @@ public abstract class DataTypeImpl implements DataType {
   public String getVersion() {
     JavaDoc.JavaDocTagList tags = this.typeDefinition.getJavaDoc().get("version");
     return tags == null ? null : tags.toString();
+  }
+
+  @Override
+  public boolean isAbstract() {
+    return this.typeDefinition.isAbstract();
   }
 
   @Override

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/ObjectDataTypeImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/ObjectDataTypeImpl.java
@@ -19,6 +19,10 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
 
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
 import org.codehaus.jackson.annotate.JsonTypeInfo;
 
 import com.webcohesion.enunciate.api.datatype.BaseType;
@@ -29,8 +33,10 @@ import com.webcohesion.enunciate.api.datatype.Value;
 import com.webcohesion.enunciate.facets.FacetFilter;
 import com.webcohesion.enunciate.modules.jackson1.model.Member;
 import com.webcohesion.enunciate.modules.jackson1.model.ObjectTypeDefinition;
+import com.webcohesion.enunciate.modules.jackson1.model.TypeDefinition;
 import com.webcohesion.enunciate.modules.jackson1.model.types.JsonClassType;
 import com.webcohesion.enunciate.modules.jackson1.model.types.JsonType;
+import com.webcohesion.enunciate.modules.jackson1.model.types.JsonTypeFactory;
 
 /**
  * @author Ryan Heaton
@@ -113,6 +119,22 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
     }
 
     return supertypes;
+  }
+
+  @Override
+  public List<DataTypeReference> getSubtypes() {
+    ArrayList<DataTypeReference> subtypes = new ArrayList<DataTypeReference>();
+    String myClassName = this.typeDefinition.getQualifiedName().toString();
+
+    for (TypeDefinition td : this.typeDefinition.getContext().getTypeDefinitions()) {
+      if (td instanceof ObjectTypeDefinition) {
+        TypeMirror superclass = td.getSuperclass();
+        if (superclass instanceof DeclaredType && (((TypeElement) ((DeclaredType) superclass).asElement()).getQualifiedName().toString().equals(myClassName))) {
+          subtypes.add(new DataTypeReferenceImpl(JsonTypeFactory.getJsonType(td.asType(), this.typeDefinition.getContext())));
+        }
+      }
+    }
+    return subtypes.isEmpty() ? null : subtypes;
   }
 
   @Override

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/ComplexDataTypeImpl.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/ComplexDataTypeImpl.java
@@ -133,6 +133,12 @@ public class ComplexDataTypeImpl extends DataTypeImpl {
   }
 
   @Override
+    public List<DataTypeReference> getSubtypes() {
+        // TODO : implement this for JAXB classes
+        return null;
+    }
+
+    @Override
   public Example getExample() {
     return this.typeDefinition.getContext().isDisableExamples() ? null : new ExampleImpl(this.typeDefinition);
   }

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/DataTypeImpl.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/DataTypeImpl.java
@@ -90,6 +90,11 @@ public abstract class DataTypeImpl implements DataType {
   }
 
   @Override
+    public List<DataTypeReference> getSubtypes() {
+        return null;
+    }
+
+    @Override
   public String getSince() {
     JavaDoc.JavaDocTagList tags = this.typeDefinition.getJavaDoc().get("since");
     return tags == null ? null : tags.toString();
@@ -102,6 +107,11 @@ public abstract class DataTypeImpl implements DataType {
   }
 
   @Override
+    public boolean isAbstract() {
+        return this.typeDefinition.isAbstract();
+    }
+
+    @Override
   public Example getExample() {
     return null;
   }


### PR DESCRIPTION
With this patch the documentation page for a type will show :
- A "abstract type" tag if the type is abstract
- A list of known subtypes
- A warning banner above the example, if the type is abstract, stating that the example is incomplete.
This works for jackson1 and jackson2 modules (there's still a TODO for subtypes in the JAXB module).