### PR TITLE
Types detection : auto-add child types of returned types. Fixes #558.

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
@@ -556,6 +556,37 @@ public class EnunciateJacksonContext extends EnunciateModuleContext implements S
         stack.pop();
       }
     }
+
+    if (subTypes == null && seeAlso == null && declaration instanceof TypeElement) {
+      // No annotation tells us what to do, so we'll look up subtypes and add them
+      Types typeUtils = getContext().getProcessingEnvironment().getTypeUtils();
+      String declarationTypeName = ((TypeElement) declaration).getQualifiedName().toString();
+      try {
+        for (Element el : getContext().getApiElements()) {
+          if (el instanceof TypeElement) {
+            TypeElement te = (TypeElement) el;
+            TypeElement superEl = (TypeElement) typeUtils.asElement(te.getSuperclass());
+            if (superEl != null && declarationTypeName.equals(superEl.getQualifiedName().toString())) {
+              add(createTypeDefinition(te), stack);
+            }
+          }
+        }
+      } catch (MirroredTypeException e) {
+        TypeMirror mirror = e.getTypeMirror();
+        Element element = typeUtils.asElement(mirror);
+        if (element instanceof TypeElement) {
+          add(createTypeDefinition((TypeElement) element), stack);
+        }
+      } catch (MirroredTypesException e) {
+        List<? extends TypeMirror> mirrors = e.getTypeMirrors();
+        for (TypeMirror mirror : mirrors) {
+          Element element = typeUtils.asElement(mirror);
+          if (element instanceof TypeElement) {
+            add(createTypeDefinition((TypeElement) element), stack);
+          }
+        }
+      }
+    }
   }
 
   /**

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
@@ -543,6 +543,37 @@ public class EnunciateJackson1Context extends EnunciateModuleContext implements 
         stack.pop();
       }
     }
+
+    if (subTypes == null && seeAlso == null && declaration instanceof TypeElement) {
+      // No annotation tells us what to do, so we'll look up subtypes and add them
+      Types typeUtils = getContext().getProcessingEnvironment().getTypeUtils();
+      String declarationTypeName = ((TypeElement) declaration).getQualifiedName().toString();
+      try {
+        for (Element el : getContext().getApiElements()) {
+          if (el instanceof TypeElement) {
+            TypeElement te = (TypeElement) el;
+            TypeElement superEl = (TypeElement) typeUtils.asElement(te.getSuperclass());
+            if (superEl != null && declarationTypeName.equals(superEl.getQualifiedName().toString())) {
+              add(createTypeDefinition(te), stack);
+            }
+          }
+        }
+      } catch (MirroredTypeException e) {
+        TypeMirror mirror = e.getTypeMirror();
+        Element element = typeUtils.asElement(mirror);
+        if (element instanceof TypeElement) {
+          add(createTypeDefinition((TypeElement) element), stack);
+        }
+      } catch (MirroredTypesException e) {
+        List<? extends TypeMirror> mirrors = e.getTypeMirrors();
+        for (TypeMirror mirror : mirrors) {
+          Element element = typeUtils.asElement(mirror);
+          if (element instanceof TypeElement) {
+            add(createTypeDefinition((TypeElement) element), stack);
+          }
+        }
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
This will only happen if no @SeeAlso or @JsonSubTypes annotation is present on the parent type.
Interfaces are not handled (ref #561), only base classes.