### PR TITLE
"Implemented interfaces" not showing up in the documentation

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/ObjectDataTypeImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/ObjectDataTypeImpl.java
@@ -108,7 +108,7 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
         ((JsonClassType) supertype).getTypeDefinition() instanceof ObjectTypeDefinition ?
           ((ObjectTypeDefinition) ((JsonClassType) supertype).getTypeDefinition()).getSupertype()
           : null
-        : null;
+          : null;
     }
 
     return supertypes;
@@ -141,18 +141,16 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
     for (TypeMirror iface : ifaces) {
       DecoratedTypeMirror decorated = (DecoratedTypeMirror) iface;
       decorated = this.typeDefinition.getContext().resolveSyntheticType(decorated);
-      if (decorated.isClass()) {
-        //if it's not an interface anymore, look up it's type.
-        TypeDefinition typeDefinition = this.typeDefinition.getContext().findTypeDefinition(((DeclaredType) decorated).asElement());
-        if (typeDefinition != null) {
-          interfaces.add(new DataTypeReferenceImpl(new JsonClassType(typeDefinition), registrationContext));
-        }
+      // look up its type.
+      TypeDefinition typeDefinition = this.typeDefinition.getContext().findTypeDefinition(((DeclaredType) decorated).asElement());
+      if (typeDefinition != null) {
+        interfaces.add(new DataTypeReferenceImpl(new JsonClassType(typeDefinition), registrationContext));
       }
     }
 
     TypeMirror superclass = clazz.getSuperclass();
     if (superclass instanceof DeclaredType) {
-      gatherInterfaces((TypeElement) ((DeclaredType)superclass).asElement(), interfaces);
+      gatherInterfaces((TypeElement) ((DeclaredType) superclass).asElement(), interfaces);
     }
   }
 

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/ObjectDataTypeImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/ObjectDataTypeImpl.java
@@ -109,7 +109,7 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
         ((JsonClassType) supertype).getTypeDefinition() instanceof ObjectTypeDefinition ?
           ((ObjectTypeDefinition) ((JsonClassType) supertype).getTypeDefinition()).getSupertype()
           : null
-        : null;
+          : null;
     }
 
     return supertypes;
@@ -142,18 +142,16 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
     for (TypeMirror iface : ifaces) {
       DecoratedTypeMirror decorated = (DecoratedTypeMirror) iface;
       decorated = this.typeDefinition.getContext().resolveSyntheticType(decorated);
-      if (decorated.isClass()) {
-        //if it's not an interface anymore, look up it's type.
-        TypeDefinition typeDefinition = this.typeDefinition.getContext().findTypeDefinition(((DeclaredType) decorated).asElement());
-        if (typeDefinition != null) {
-          interfaces.add(new DataTypeReferenceImpl(new JsonClassType(typeDefinition), registrationContext));
-        }
+      // look up its type.
+      TypeDefinition typeDefinition = this.typeDefinition.getContext().findTypeDefinition(((DeclaredType) decorated).asElement());
+      if (typeDefinition != null) {
+        interfaces.add(new DataTypeReferenceImpl(new JsonClassType(typeDefinition), registrationContext));
       }
     }
 
     TypeMirror superclass = clazz.getSuperclass();
     if (superclass instanceof DeclaredType) {
-      gatherInterfaces((TypeElement) ((DeclaredType)superclass).asElement(), interfaces);
+      gatherInterfaces((TypeElement) ((DeclaredType) superclass).asElement(), interfaces);
     }
   }
 


### PR DESCRIPTION
"Implemented interfaces" was not showing up in the documentation even after fix for #561 from e3259fce.

I'm not sure what the decorated.isClass() test was meant to, but it prevented the interfaces list to be filled and the information to show up in the documentation page.