### PR TITLE
Debug & improvements on raw link detection

### DIFF
--- a/docs/src/main/java/com/webcohesion/enunciate/modules/docs/ApiDocsJavaDocTagHandler.java
+++ b/docs/src/main/java/com/webcohesion/enunciate/modules/docs/ApiDocsJavaDocTagHandler.java
@@ -26,7 +26,7 @@ import java.util.regex.Pattern;
  */
 public class ApiDocsJavaDocTagHandler implements JavaDocTagHandler {
 
-  static final Pattern RAW_LINK_PATTERN = Pattern.compile("[^>=\"'](http.*?)[\"' $]");
+  static final Pattern RAW_LINK_PATTERN = Pattern.compile("(?:^|[^>=\"'])(http.[^\"'<\\s]+)(?![^<>]*>|[^\"]*?<\\/a)");
 
   private final ApiRegistry registry;
   private final ApiRegistrationContext context;
@@ -192,7 +192,7 @@ public class ApiDocsJavaDocTagHandler implements JavaDocTagHandler {
       }
     }
     else {
-      return RAW_LINK_PATTERN.matcher(value).replaceAll(" <a href=\"$1\">$1</a> ");
+      return RAW_LINK_PATTERN.matcher(value).replaceAll(" <a target=\"_blank\" href=\"$1\">$1</a>");
     }
   }
 }

--- a/docs/src/test/java/com/webcohesion/enunciate/modules/docs/TestApiDocsJavaDocTagHandler.java
+++ b/docs/src/test/java/com/webcohesion/enunciate/modules/docs/TestApiDocsJavaDocTagHandler.java
@@ -13,10 +13,17 @@ public class TestApiDocsJavaDocTagHandler extends TestCase {
     assertFalse(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("<a href=http://blah.com>blah</a>").find());
     assertFalse(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("<a href=\"http://blah.com\">http://blah.com</a>").find());
     assertFalse(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("<a href=\"http://blah.com\">the thing for http://blah.com</a>").find());
+    assertFalse(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("<img src=\"http://blah.com/img.png\"/>").find());
+    assertFalse(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("Some inline image <img src=\"http://blah.com/img.png\"/> in the middle of text").find());
+    assertTrue(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("http://blah.com").find());
+    assertTrue(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("Something to see on http://blah.com").find());
+    assertTrue(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("http://blah.com has more info").find());
+    assertTrue(ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("Just in case, http://blah.com has more info").find());
     Matcher rawLink = ApiDocsJavaDocTagHandler.RAW_LINK_PATTERN.matcher("You can see http://blah.com for more info");
     assertTrue(rawLink.find());
     assertEquals("http://blah.com", rawLink.group(1));
-    assertEquals("You can see <a href=\"http://blah.com\">http://blah.com</a> for more info", rawLink.replaceAll(" <a href=\"$1\">$1</a> "));
+    assertEquals("You can see <a href=\"http://blah.com\">http://blah.com</a> for more info", rawLink.replaceAll(" <a href=\"$1\">$1</a>"));
+    assertEquals("You can see <a target=\"_blank\" href=\"http://blah.com\">http://blah.com</a> for more info", rawLink.replaceAll(" <a target=\"_blank\" href=\"$1\">$1</a>"));
   }
 
 }

--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/javadoc/JavaDoc.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/javadoc/JavaDoc.java
@@ -42,6 +42,7 @@ public class JavaDoc extends HashMap<String, JavaDoc.JavaDocTagList> {
 
   private static final Pattern INLINE_TAG_PATTERN = Pattern.compile("\\{@([^\\} ]+) ?(.*?)\\}");
   private static final Pattern INHERITDOC_PATTERN = Pattern.compile("\\{@inheritDoc(.*?)\\}");
+  private static final Pattern RAW_LINK_PATTERN = Pattern.compile("(?:^|[^>=\"'])(http.[^\"'<\\s]+)(?![^<>]*>|[^\"]*?<\\/a)");
   private static final char[] WHITESPACE_CHARS = new char[]{' ', '\t', '\n', 0x0B, '\f', '\r'};
 
   protected String value;
@@ -165,7 +166,9 @@ public class JavaDoc extends HashMap<String, JavaDoc.JavaDocTagList> {
     }
     builder.append(value.substring(lastStart, value.length()));
 
-    return handler.onBlockTag(section, builder.toString(), context);
+	String result = handler.onBlockTag(section, builder.toString(), context);
+	// replace all remaining raw links
+	return RAW_LINK_PATTERN.matcher(result).replaceAll(" <a target=\"_blank\" href=\"$1\">$1</a>");
   }
 
   /**


### PR DESCRIPTION
I found an issue : the raw link was not being replaced if it was touching the begin/end of the string.
I changed the regexp a bit, from the solution here : http://stackoverflow.com/questions/35553751/javascript-regex-find-all-urls-outside-a-tags-nested-tags
It fixes the problen, and also handles properly urls mixed with text within <a> tags.

I also changed JavaDoc.java so that raw links are now replaced throughout the whole javadoc (not only in block tags), and added a target=_blank attribute.