### PR TITLE
Allow mixin annotations also for known types

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
@@ -207,6 +207,12 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
     knownTypes.put("java.time.OffsetDateTime", this.dateType);
     knownTypes.put("org.joda.time.DateTime", this.dateType);
     knownTypes.put("java.util.Currency", KnownJsonType.STRING);
+    
+    for (String m : this.mixins.keySet()) {
+      if (knownTypes.remove(m) != null) {
+        debug("Unregistering %s from known types, as it is redefined using a mixin.", m);
+      }
+    }
 
     return knownTypes;
   }

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
@@ -200,6 +200,12 @@ public class EnunciateJackson1Context extends EnunciateModuleContext {
     knownTypes.put("java.time.OffsetDateTime", this.dateType);
     knownTypes.put("org.joda.time.DateTime", this.dateType);
     knownTypes.put("java.util.Currency", KnownJsonType.STRING);
+    
+    for (String m : this.mixins.keySet()) {
+      if (knownTypes.remove(m) != null) {
+        debug("Unregistering %s from known types, as it is redefined using a mixin.", m);
+      }
+    }
 
     return knownTypes;
   }


### PR DESCRIPTION
As noted in the last comment of #626, mixins cannot be used for known types and I think it would be nice to allow them.
This simple patch makes any type "unknown" if there is a mixin registered for it. It is supposed that the mixin will take care of everything.
There is a slight breach of backward compatibility, because such configuration did nothing before.

Of course, feel free to edit/change/comment on this.