### PR TITLE
Configurable default visibility in Jackson modules (ENUNCIATE-627)

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
@@ -67,11 +67,13 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
   private final Map<String, String> mixins;
   private final boolean disableExamples;
   private final boolean wrapRootValue;
+  private final AccessorVisibilityChecker defaultVisibility;
 
-  public EnunciateJacksonContext(EnunciateContext context, boolean honorJaxb, KnownJsonType dateType, boolean collapseTypeHierarchy, Map<String, String> mixins, boolean disableExamples, boolean wrapRootValue) {
+  public EnunciateJacksonContext(EnunciateContext context, boolean honorJaxb, KnownJsonType dateType, boolean collapseTypeHierarchy, Map<String, String> mixins, AccessorVisibilityChecker visibility, boolean disableExamples, boolean wrapRootValue) {
     super(context);
     this.dateType = dateType;
     this.mixins = mixins;
+    this.defaultVisibility = visibility;
     this.disableExamples = disableExamples;
     this.knownTypes = loadKnownTypes();
     this.typeDefinitions = new HashMap<String, TypeDefinition>();
@@ -284,6 +286,10 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
 
   public boolean isIgnored(Element el) {
     return IgnoreUtils.isIgnored(el) || (el.getAnnotation(JsonIgnore.class) != null && el.getAnnotation(JsonIgnore.class).value());
+  }
+  
+  public AccessorVisibilityChecker getDefaultVisibility() {
+    return this.defaultVisibility;
   }
 
   public void add(TypeDefinition typeDef, LinkedList<Element> stack) {

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/AccessorVisibilityChecker.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/AccessorVisibilityChecker.java
@@ -1,0 +1,77 @@
+package com.webcohesion.enunciate.modules.jackson.model;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
+
+/**
+ * Jackson visibility checker settings for each of the accessor methods.
+ * It would be nice to use the standard Jackson checker directly
+ * ({@link VisibilityChecker.Std}).
+ * Unfortunately enough, it does not allow to <em>read</em> values stored in it.
+ *
+ * @author Martin Kacer
+ */
+public class AccessorVisibilityChecker {
+  
+  private final Map<PropertyAccessor,Visibility> minLevels;
+  
+  public static final JsonAutoDetect DEFAULT_VISIBILITY = VisibilityChecker.Std.class.getAnnotation(JsonAutoDetect.class);
+  public static final AccessorVisibilityChecker DEFAULT_CHECKER = new AccessorVisibilityChecker(DEFAULT_VISIBILITY);
+
+  private AccessorVisibilityChecker(Map<PropertyAccessor,Visibility> minLevels) {
+    this.minLevels = minLevels;
+  }
+  
+  public AccessorVisibilityChecker(JsonAutoDetect annotation) {
+    this(createMap(annotation.getterVisibility(), annotation.isGetterVisibility(),
+        annotation.setterVisibility(), annotation.creatorVisibility(), annotation.fieldVisibility()));
+  }
+  
+  public AccessorVisibilityChecker with(JsonAutoDetect annotation) {
+    return new AccessorVisibilityChecker(createMap(
+        (annotation.getterVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).getterVisibility(),
+        (annotation.isGetterVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).isGetterVisibility(),
+        (annotation.setterVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).setterVisibility(),
+        (annotation.creatorVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).creatorVisibility(),
+        (annotation.fieldVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).fieldVisibility()));
+  }
+  
+  public AccessorVisibilityChecker withVisibility(PropertyAccessor method, Visibility level) {
+    return new AccessorVisibilityChecker(changeMap(minLevels, method, level));
+  }
+  
+  /**
+   * This should always return a non-null value for "normal" usage and accessor methods.
+   */
+  public Visibility getVisibility(PropertyAccessor method) {
+    return minLevels.get(method);
+  }
+  
+  private static Map<PropertyAccessor,Visibility> createMap(Visibility getterLevel, Visibility isGetterLevel,
+      Visibility setterLevel, Visibility creatorLevel, Visibility fieldLevel) {
+    EnumMap<PropertyAccessor, Visibility> levels = new EnumMap<PropertyAccessor, Visibility>(PropertyAccessor.class);
+    levels.put(PropertyAccessor.GETTER, getterLevel);
+    levels.put(PropertyAccessor.IS_GETTER, isGetterLevel);
+    levels.put(PropertyAccessor.SETTER, setterLevel);
+    levels.put(PropertyAccessor.CREATOR, creatorLevel);
+    levels.put(PropertyAccessor.FIELD, fieldLevel);
+    return Collections.unmodifiableMap(levels);
+  }
+  
+  private static Map<PropertyAccessor,Visibility> changeMap(Map<PropertyAccessor,Visibility> original,
+      PropertyAccessor method, Visibility level) {
+    EnumMap<PropertyAccessor, Visibility> levels = new EnumMap<PropertyAccessor, Visibility>(PropertyAccessor.class);
+    if (method == PropertyAccessor.ALL) {
+      return createMap(level, level, level, level, level);
+    }
+    levels.putAll(original);
+    levels.put(method, level);
+    return Collections.unmodifiableMap(levels);
+  }
+}

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
@@ -82,7 +82,7 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
     WildcardMember wildcardMember = null;
     JsonIgnoreType ignoreType = getAnnotation(JsonIgnoreType.class);
     if (ignoreType == null || !ignoreType.value()) {
-      AccessorFilter filter = new AccessorFilter(getAnnotation(JsonAutoDetect.class), getAnnotation(JsonIgnoreProperties.class), context.isHonorJaxb(), getAnnotation(XmlAccessorType.class));
+      AccessorFilter filter = new AccessorFilter(getAnnotation(JsonAutoDetect.class), getAnnotation(JsonIgnoreProperties.class), context.isHonorJaxb(), getAnnotation(XmlAccessorType.class), context.getDefaultVisibility());
       value = null;
 
       wildcardMember = null;

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
@@ -64,13 +64,15 @@ public class EnunciateJackson1Context extends EnunciateModuleContext {
   private final KnownJsonType dateType;
   private final boolean collapseTypeHierarchy;
   private final Map<String, String> mixins;
+  private final AccessorVisibilityChecker defaultVisibility;
   private final boolean disableExamples;
   private final boolean wrapRootValue;
 
-  public EnunciateJackson1Context(EnunciateContext context, boolean honorJaxb, KnownJsonType dateType, boolean collapseTypeHierarchy, Map<String, String> mixins, boolean disableExamples, boolean wrapRootValue) {
+  public EnunciateJackson1Context(EnunciateContext context, boolean honorJaxb, KnownJsonType dateType, boolean collapseTypeHierarchy, Map<String, String> mixins, AccessorVisibilityChecker visibility, boolean disableExamples, boolean wrapRootValue) {
     super(context);
     this.dateType = dateType;
     this.mixins = mixins;
+    this.defaultVisibility = visibility;
     this.collapseTypeHierarchy = collapseTypeHierarchy;
     this.disableExamples = disableExamples;
     this.knownTypes = loadKnownTypes();
@@ -272,6 +274,10 @@ public class EnunciateJackson1Context extends EnunciateModuleContext {
 
   public boolean isIgnored(Element el) {
     return IgnoreUtils.isIgnored(el) || (el.getAnnotation(JsonIgnore.class) != null && el.getAnnotation(JsonIgnore.class).value());
+  }
+
+  public AccessorVisibilityChecker getDefaultVisibility() {
+    return defaultVisibility;
   }
 
   public void add(TypeDefinition typeDef, LinkedList<Element> stack) {

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/AccessorVisibilityChecker.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/AccessorVisibilityChecker.java
@@ -1,0 +1,77 @@
+package com.webcohesion.enunciate.modules.jackson1.model;
+
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+
+import org.codehaus.jackson.annotate.JsonAutoDetect;
+import org.codehaus.jackson.annotate.JsonAutoDetect.Visibility;
+import org.codehaus.jackson.annotate.JsonMethod;
+import org.codehaus.jackson.map.introspect.VisibilityChecker;
+
+/**
+ * Jackson visibility checker settings for each of the accessor methods.
+ * It would be nice to use the standard Jackson checker directly
+ * ({@link VisibilityChecker.Std}).
+ * Unfortunately enough, it does not allow to <em>read</em> values stored in it.
+ *
+ * @author Martin Kacer
+ */
+public class AccessorVisibilityChecker {
+  
+  private final Map<JsonMethod,Visibility> minLevels;
+  
+  public static final JsonAutoDetect DEFAULT_VISIBILITY = VisibilityChecker.Std.class.getAnnotation(JsonAutoDetect.class);
+  public static final AccessorVisibilityChecker DEFAULT_CHECKER = new AccessorVisibilityChecker(DEFAULT_VISIBILITY);
+
+  private AccessorVisibilityChecker(Map<JsonMethod,Visibility> minLevels) {
+    this.minLevels = minLevels;
+  }
+  
+  public AccessorVisibilityChecker(JsonAutoDetect annotation) {
+    this(createMap(annotation.getterVisibility(), annotation.isGetterVisibility(),
+        annotation.setterVisibility(), annotation.creatorVisibility(), annotation.fieldVisibility()));
+  }
+  
+  public AccessorVisibilityChecker with(JsonAutoDetect annotation) {
+    return new AccessorVisibilityChecker(createMap(
+        (annotation.getterVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).getterVisibility(),
+        (annotation.isGetterVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).isGetterVisibility(),
+        (annotation.setterVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).setterVisibility(),
+        (annotation.creatorVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).creatorVisibility(),
+        (annotation.fieldVisibility() == Visibility.DEFAULT ? DEFAULT_VISIBILITY : annotation).fieldVisibility()));
+  }
+  
+  public AccessorVisibilityChecker withVisibility(JsonMethod method, Visibility level) {
+    return new AccessorVisibilityChecker(changeMap(minLevels, method, level));
+  }
+  
+  /**
+   * This should always return a non-null value for "normal" usage and accessor methods.
+   */
+  public Visibility getVisibility(JsonMethod method) {
+    return minLevels.get(method);
+  }
+  
+  private static Map<JsonMethod,Visibility> createMap(Visibility getterLevel, Visibility isGetterLevel,
+      Visibility setterLevel, Visibility creatorLevel, Visibility fieldLevel) {
+    EnumMap<JsonMethod, Visibility> levels = new EnumMap<JsonMethod, Visibility>(JsonMethod.class);
+    levels.put(JsonMethod.GETTER, getterLevel);
+    levels.put(JsonMethod.IS_GETTER, isGetterLevel);
+    levels.put(JsonMethod.SETTER, setterLevel);
+    levels.put(JsonMethod.CREATOR, creatorLevel);
+    levels.put(JsonMethod.FIELD, fieldLevel);
+    return Collections.unmodifiableMap(levels);
+  }
+  
+  private static Map<JsonMethod,Visibility> changeMap(Map<JsonMethod,Visibility> original,
+      JsonMethod method, Visibility level) {
+    EnumMap<JsonMethod, Visibility> levels = new EnumMap<JsonMethod, Visibility>(JsonMethod.class);
+    if (method == JsonMethod.ALL) {
+      return createMap(level, level, level, level, level);
+    }
+    levels.putAll(original);
+    levels.put(method, level);
+    return Collections.unmodifiableMap(levels);
+  }
+}

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
@@ -82,7 +82,7 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
     WildcardMember wildcardMember = null;
     JsonIgnoreType ignoreType = getAnnotation(JsonIgnoreType.class);
     if (ignoreType == null || !ignoreType.value()) {
-      AccessorFilter filter = new AccessorFilter(getAnnotation(JsonAutoDetect.class), getAnnotation(JsonIgnoreProperties.class), context.isHonorJaxb(), getAnnotation(XmlAccessorType.class));
+      AccessorFilter filter = new AccessorFilter(getAnnotation(JsonAutoDetect.class), getAnnotation(JsonIgnoreProperties.class), context.isHonorJaxb(), getAnnotation(XmlAccessorType.class), context.getDefaultVisibility());
       value = null;
 
       wildcardMember = null;

--- a/top/src/main/resources/META-INF/enunciate-2.9.0.xsd
+++ b/top/src/main/resources/META-INF/enunciate-2.9.0.xsd
@@ -683,6 +683,13 @@
               </xs:documentation>
             </xs:annotation>
           </xs:element>
+          <xs:element name="visibility-check" minOccurs="0" maxOccurs="unbounded" type="visibility-check">
+            <xs:annotation>
+              <xs:documentation>
+                Default visibility set in ObjectMapper visibility checker.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
         </xs:sequence>
         <xs:attribute name="honorJaxb" type="xs:boolean">
           <xs:annotation>
@@ -726,6 +733,13 @@
             <xs:annotation>
               <xs:documentation>
                 A Jackson mixin annotation.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="visibility-check" minOccurs="0" maxOccurs="unbounded" type="visibility-check">
+            <xs:annotation>
+              <xs:documentation>
+                Default visibility set in ObjectMapper visibility checker.
               </xs:documentation>
             </xs:annotation>
           </xs:element>
@@ -1131,6 +1145,89 @@
       </xs:annotation>
     </xs:attribute>
   </xs:complexType>
+
+  <xs:complexType name="visibility-check">
+    <xs:attribute name="method" type="property-accessor" use="required">
+      <xs:annotation>
+        <xs:documentation>The property accessor type / method to be checked.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="visibility" type="visibility" use="required">
+      <xs:annotation>
+        <xs:documentation>Default minimal visibility (unless overridden with JsonAutoDetect).</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+
+  <xs:simpleType name="property-accessor">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="getter">
+        <xs:annotation>
+          <xs:documentation>Getters are methods used to get a POJO field value for serialization. (PropertyAccessor.GETTER)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="setter">
+        <xs:annotation>
+          <xs:documentation>Setters are methods used to set a POJO value for deserialization. (PropertyAccessor.SETTER)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="creator">
+        <xs:annotation>
+          <xs:documentation>Creators are constructors and (static) factory methods used to construct POJO instances for deserialization. (PropertyAccessor.CREATOR)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="field">
+        <xs:annotation>
+          <xs:documentation>Field refers to fields of regular Java objects. (PropertyAccessor.FIELD)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="is_getter">
+        <xs:annotation>
+          <xs:documentation>"Getter-like methods that are named "isXxx" and return boolean value. (PropertyAccessor.IS_GETTER)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="all">
+        <xs:annotation>
+          <xs:documentation>This pseudo-type indicates that all accessors are affected. (PropertyAccessor.ALL)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="visibility">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="any">
+        <xs:annotation>
+          <xs:documentation>Value that means that all kinds of access modifiers are acceptable, from private to public. (JsonAutoDetect.Visibility.ANY)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="non_private">
+        <xs:annotation>
+          <xs:documentation>Value that means that any other access modifier other than 'private' is considered auto-detectable. (JsonAutoDetect.Visibility.NON_PRIVATE)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="protected_and_public">
+        <xs:annotation>
+          <xs:documentation>Value that means access modifiers 'protected' and 'public' are auto-detectable. (JsonAutoDetect.Visibility.PROTECTED_AND_PUBLIC)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="public_only">
+        <xs:annotation>
+          <xs:documentation>Value to indicate that only 'public' access modifier is considered auto-detectable. (JsonAutoDetect.Visibility.PUBLIC_ONLY)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="none">
+        <xs:annotation>
+          <xs:documentation>Value that indicates that no access modifiers are auto-detectable. (JsonAutoDetect.Visibility.NONE)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="default">
+        <xs:annotation>
+          <xs:documentation>Value that indicates that default visibility level is to be used. (JsonAutoDetect.Visibility.DEFAULT)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
 
   <xs:complexType name="application-context">
     <xs:attribute name="path">


### PR DESCRIPTION
Ok, here is my first try at #627.

If the new configuration is not used, the default behavior should be as before, except for one thing:
The default visibility for setters used to be PUBLIC_ONLY (as for anything else) but it is now ANY - because it is what Jackson really does and I just take it from there - see `com.fasterxml.jackson.databind.introspect.VisibilityChecker.Std`.
If you have any reason for Enunciate to behave differently from Jackson, it is relatively easy to change.

Also, I do not know whether there are any automatic tests or how to execute them. So I just tested manually (and only for Jackson module, not Jackson1).