### PR TITLE
Add format information to Swagger resource arguments

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/api/resources/Parameter.java
+++ b/core/src/main/java/com/webcohesion/enunciate/api/resources/Parameter.java
@@ -15,11 +15,12 @@
  */
 package com.webcohesion.enunciate.api.resources;
 
+import java.util.Set;
+
 import com.webcohesion.enunciate.api.HasAnnotations;
 import com.webcohesion.enunciate.api.HasStyles;
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
-
-import java.util.Set;
 
 /**
  * @author Ryan Heaton
@@ -33,6 +34,8 @@ public interface Parameter extends HasStyles, HasAnnotations {
   String getTypeLabel();
 
   String getTypeName();
+
+  BaseTypeFormat getTypeFormat();
 
   String getDefaultValue();
 

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ParameterImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ParameterImpl.java
@@ -15,19 +15,21 @@
  */
 package com.webcohesion.enunciate.modules.jaxrs.api.impl;
 
+import java.lang.annotation.Annotation;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import javax.lang.model.element.AnnotationMirror;
+
 import com.webcohesion.enunciate.api.ApiRegistrationContext;
 import com.webcohesion.enunciate.api.Styles;
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
 import com.webcohesion.enunciate.api.resources.Parameter;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.modules.jaxrs.model.ResourceParameter;
 import com.webcohesion.enunciate.modules.jaxrs.model.ResourceParameterConstraints;
 import com.webcohesion.enunciate.util.BeanValidationUtils;
-
-import javax.lang.model.element.AnnotationMirror;
-import java.lang.annotation.Annotation;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * @author Ryan Heaton
@@ -59,7 +61,12 @@ public class ParameterImpl implements Parameter {
 
   @Override
   public String getTypeName() {
-    return this.param.getDataType().name().toLowerCase();
+    return this.param.getDataType().name;
+  }
+
+  @Override
+  public BaseTypeFormat getTypeFormat() {
+    return this.param.getDataType().format;
   }
 
   @Override

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ResponseHeaderParameterImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ResponseHeaderParameterImpl.java
@@ -15,8 +15,8 @@
  */
 package com.webcohesion.enunciate.modules.jaxrs.api.impl;
 
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
 import com.webcohesion.enunciate.api.resources.Parameter;
-import com.webcohesion.enunciate.javac.javadoc.DefaultJavaDocTagHandler;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 
 import javax.lang.model.element.AnnotationMirror;
@@ -98,5 +98,10 @@ public class ResponseHeaderParameterImpl implements Parameter {
   @Override
   public Set<String> getStyles() {
     return styles;
+  }
+
+  @Override
+  public BaseTypeFormat getTypeFormat() {
+    return null;
   }
 }

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceParameter.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceParameter.java
@@ -441,13 +441,15 @@ public class ResourceParameter extends DecoratedElement<Element> implements Comp
       switch (type.getKind()) {
         case BOOLEAN:
           return ResourceParameterDataType.BOOLEAN;
-        case INT:
-          return ResourceParameterDataType.INTEGER;
-        case DOUBLE:
-        case FLOAT:
-        case LONG:
         case SHORT:
-          return ResourceParameterDataType.NUMBER;
+        case INT:
+          return ResourceParameterDataType.INT32;
+        case LONG:
+          return ResourceParameterDataType.INT64;
+        case DOUBLE:
+          return ResourceParameterDataType.DOUBLE;
+        case FLOAT:
+          return ResourceParameterDataType.FLOAT;
         default:
           return ResourceParameterDataType.STRING;
       }

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceParameterDataType.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceParameterDataType.java
@@ -15,18 +15,25 @@
  */
 package com.webcohesion.enunciate.modules.jaxrs.model;
 
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
+
 /**
  * @author Ryan Heaton
  */
 public enum ResourceParameterDataType {
+  BOOLEAN("boolean", null),
+  INT32("integer", BaseTypeFormat.INT32),
+  INT64("integer", BaseTypeFormat.INT64),
+  DOUBLE("number", BaseTypeFormat.DOUBLE),
+  FLOAT("number", BaseTypeFormat.FLOAT),
+  STRING("string", null),
+  FILE("file", null);
 
-  BOOLEAN,
+  public final String name;
+  public final BaseTypeFormat format;
 
-  INTEGER,
-
-  NUMBER,
-
-  STRING,
-
-  FILE
+  private ResourceParameterDataType(String name, BaseTypeFormat format) {
+    this.name = name;
+    this.format = format;
+  }
 }

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ParameterImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ParameterImpl.java
@@ -16,6 +16,7 @@
 package com.webcohesion.enunciate.modules.spring_web.api.impl;
 
 import com.webcohesion.enunciate.api.Styles;
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
 import com.webcohesion.enunciate.api.resources.Parameter;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.modules.spring_web.model.RequestParameter;
@@ -178,5 +179,10 @@ public class ParameterImpl implements Parameter {
   @Override
   public Set<String> getStyles() {
     return Styles.gatherStyles(this.param, Collections.<String, String>emptyMap());
+  }
+
+  @Override
+  public BaseTypeFormat getTypeFormat() {
+    return null;
   }
 }

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ResponseHeaderParameterImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ResponseHeaderParameterImpl.java
@@ -15,6 +15,7 @@
  */
 package com.webcohesion.enunciate.modules.spring_web.api.impl;
 
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
 import com.webcohesion.enunciate.api.resources.Parameter;
 import com.webcohesion.enunciate.javac.javadoc.DefaultJavaDocTagHandler;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
@@ -98,5 +99,10 @@ public class ResponseHeaderParameterImpl implements Parameter {
   @Override
   public Set<String> getStyles() {
     return styles;
+  }
+
+  @Override
+  public BaseTypeFormat getTypeFormat() {
+    return null;
   }
 }

--- a/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/BaseTypeToSwagger.java
+++ b/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/BaseTypeToSwagger.java
@@ -1,0 +1,21 @@
+package com.webcohesion.enunciate.modules.swagger;
+
+import java.util.Map;
+import java.util.EnumMap;
+
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
+
+public class BaseTypeToSwagger {
+
+  private static final Map<BaseTypeFormat, String> baseformat2swaggerformat = new EnumMap<BaseTypeFormat, String>(BaseTypeFormat.class);
+  static {
+    baseformat2swaggerformat.put(BaseTypeFormat.INT32, "int32");
+    baseformat2swaggerformat.put(BaseTypeFormat.INT64, "int64");
+    baseformat2swaggerformat.put(BaseTypeFormat.FLOAT, "float");
+    baseformat2swaggerformat.put(BaseTypeFormat.DOUBLE, "double");
+  }
+
+  public static String toSwaggerFormat(BaseTypeFormat format) {
+    return format == null ? null : baseformat2swaggerformat.get(format);
+  }
+}

--- a/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/DataFormatNameForMethod.java
+++ b/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/DataFormatNameForMethod.java
@@ -57,7 +57,6 @@ public class DataFormatNameForMethod implements TemplateMethodModelEx {
     }
     DataTypeReference reference = DataTypeReference.class.cast(unwrapped);
 
-    BaseTypeFormat format = reference.getBaseTypeFormat();
-    return format == null ? null : baseformat2swaggerformat.get(format);
+    return BaseTypeToSwagger.toSwaggerFormat(reference.getBaseTypeFormat());
   }
 }

--- a/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/SwaggerParameter.java
+++ b/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/SwaggerParameter.java
@@ -15,6 +15,7 @@
  */
 package com.webcohesion.enunciate.modules.swagger;
 
+import com.webcohesion.enunciate.api.datatype.BaseTypeFormat;
 import com.webcohesion.enunciate.api.resources.Parameter;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 
@@ -94,5 +95,14 @@ public class SwaggerParameter implements Parameter {
   @Override
   public Set<String> getStyles() {
     return delegate.getStyles();
+  }
+
+  @Override
+  public BaseTypeFormat getTypeFormat() {
+    return delegate.getTypeFormat();
+  }
+
+  public String getTypeFormatName() {
+    return BaseTypeToSwagger.toSwaggerFormat(getTypeFormat());
   }
 }

--- a/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/swagger.fmt
+++ b/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/swagger.fmt
@@ -220,6 +220,9 @@
                   [#if parameter.constraintValues??]
             "type" : "${parameter.typeName}",
             "enum" : [[#list parameter.constraintValues as constraintValue]"${constraintValue}"[#if constraintValue_has_next], [/#if][/#list]][#if !parameter.multivalued],[/#if]
+                  [#elseif parameter.typeFormatName??]
+            "type" : "${parameter.typeName}",
+            "format" : "${parameter.typeFormatName}"[#if !parameter.multivalued],[/#if]
                   [#else]
             "type" : "${parameter.typeName}"[#if !parameter.multivalued],[/#if]
                   [/#if]


### PR DESCRIPTION
Add format information to Swagger resource arguments

Continues the work of 5d72a12

This adds BaseTypeFormat to the Parameter interface.
Again I have just null-ed out implementations in other frontends
than JAX-RS.

In JAX-RS the parameter data type handling has been extended to retain
both type and format.

Swagger backend uses the parameter format if present.