### PR TITLE
option to retain original resource names

### DIFF
--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
@@ -62,12 +62,12 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
   private PathSortStrategy pathSortStrategy = PathSortStrategy.breadth_first;
   private InterfaceDescriptionFile wadlFile = null;
   private final boolean disableExamples;
-  private final boolean originalResourceNames;
+  private final boolean keepOriginalMethodNames;
 
-  public EnunciateJaxrsContext(EnunciateContext context, boolean disableExamples, boolean originalResourceNames) {
+  public EnunciateJaxrsContext(EnunciateContext context, boolean disableExamples, boolean keepOriginalMethodNames) {
     super(context);
     this.disableExamples = disableExamples;
-    this.originalResourceNames = originalResourceNames;
+    this.keepOriginalMethodNames = keepOriginalMethodNames;
     this.mediaTypeIds = loadKnownMediaTypes();
     this.rootResources = new TreeSet<RootResource>(new RootResourceComparator());
     this.providers = new TreeSet<TypeElement>(new TypeElementComparator());
@@ -160,8 +160,8 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
     return disableExamples;
   }
 
-  public boolean isOriginalResourceNames() {
-    return originalResourceNames;
+  public boolean isKeepOriginalMethodNames() {
+    return keepOriginalMethodNames;
   }
 
   /**

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
@@ -62,10 +62,12 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
   private PathSortStrategy pathSortStrategy = PathSortStrategy.breadth_first;
   private InterfaceDescriptionFile wadlFile = null;
   private final boolean disableExamples;
+  private final boolean originalResourceNames;
 
-  public EnunciateJaxrsContext(EnunciateContext context, boolean disableExamples) {
+  public EnunciateJaxrsContext(EnunciateContext context, boolean disableExamples, boolean originalResourceNames) {
     super(context);
     this.disableExamples = disableExamples;
+    this.originalResourceNames = originalResourceNames;
     this.mediaTypeIds = loadKnownMediaTypes();
     this.rootResources = new TreeSet<RootResource>(new RootResourceComparator());
     this.providers = new TreeSet<TypeElement>(new TypeElementComparator());
@@ -156,6 +158,10 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
 
   public boolean isDisableExamples() {
     return disableExamples;
+  }
+
+  public boolean isOriginalResourceNames() {
+    return originalResourceNames;
   }
 
   /**

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/JaxrsModule.java
@@ -101,6 +101,10 @@ public class JaxrsModule extends BasicProviderModule implements TypeDetectingMod
     return this.config.getBoolean("[@disableExamples]", false);
   }
 
+  public boolean isOriginalResourceNames() {
+    return this.config.getBoolean("[@originalResourceNames]", false);
+  }
+
   public void setDefaultSortStrategy(PathSortStrategy defaultSortStrategy) {
     this.defaultSortStrategy = defaultSortStrategy;
   }
@@ -116,7 +120,7 @@ public class JaxrsModule extends BasicProviderModule implements TypeDetectingMod
 
   @Override
   public void call(EnunciateContext context) {
-    jaxrsContext = new EnunciateJaxrsContext(context, isDisableExamples());
+    jaxrsContext = new EnunciateJaxrsContext(context, isDisableExamples(), isOriginalResourceNames());
 
     DataTypeDetectionStrategy detectionStrategy = getDataTypeDetectionStrategy();
     String relativeContextPath = "";

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/JaxrsModule.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/JaxrsModule.java
@@ -101,8 +101,8 @@ public class JaxrsModule extends BasicProviderModule implements TypeDetectingMod
     return this.config.getBoolean("[@disableExamples]", false);
   }
 
-  public boolean isOriginalResourceNames() {
-    return this.config.getBoolean("[@originalResourceNames]", false);
+  public boolean isKeepOriginalMethodNames() {
+    return this.config.getBoolean("[@keepOriginalMethodNames]", false);
   }
 
   public void setDefaultSortStrategy(PathSortStrategy defaultSortStrategy) {
@@ -120,7 +120,7 @@ public class JaxrsModule extends BasicProviderModule implements TypeDetectingMod
 
   @Override
   public void call(EnunciateContext context) {
-    jaxrsContext = new EnunciateJaxrsContext(context, isDisableExamples(), isOriginalResourceNames());
+    jaxrsContext = new EnunciateJaxrsContext(context, isDisableExamples(), isKeepOriginalMethodNames());
 
     DataTypeDetectionStrategy detectionStrategy = getDataTypeDetectionStrategy();
     String relativeContextPath = "";

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/MethodImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/MethodImpl.java
@@ -66,7 +66,7 @@ public class MethodImpl implements Method {
 
   @Override
   public String getSlug() {
-    if (this.resourceMethod.getContext().isOriginalResourceNames()) {
+    if (this.resourceMethod.getContext().isKeepOriginalMethodNames()) {
       return resourceMethod.getSlug();
     } else {
       return this.group.getSlug() + "_" + resourceMethod.getSlug() + "_" + this.httpMethod;

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/MethodImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/MethodImpl.java
@@ -66,7 +66,11 @@ public class MethodImpl implements Method {
 
   @Override
   public String getSlug() {
-    return this.group.getSlug() + "_" + resourceMethod.getSlug() + "_" + this.httpMethod;
+    if (this.resourceMethod.getContext().isOriginalResourceNames()) {
+      return resourceMethod.getSlug();
+    } else {
+      return this.group.getSlug() + "_" + resourceMethod.getSlug() + "_" + this.httpMethod;
+    }
   }
 
   @Override

--- a/top/src/main/resources/META-INF/enunciate-2.10.0.xsd
+++ b/top/src/main/resources/META-INF/enunciate-2.10.0.xsd
@@ -902,6 +902,11 @@
             <xs:documentation>Whether to disable examples in any generated documentation.</xs:documentation>
           </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="keepOriginalMethodNames" type="xs:boolean">
+          <xs:annotation>
+            <xs:documentation>Whether to keep original resource method names.</xs:documentation>
+          </xs:annotation>
+        </xs:attribute>
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>


### PR DESCRIPTION
Allow the original resource method names to be retained instead of using synthetic (very long) method names.

Again, this is done to make Swagger generation prettier. I am not sure how the slug() method is otherwise used, so am unsure of what other impact using the option might have.

I also changed the XSD, but it was already invalid (as per http://www.utilities-online.info/xsdvalidation/). I hope my change is valid (not much of an XSD hacker).

If accepted, the JAX-RS wiki documentation should be amended with:

keepOriginalMethodNames|(Since 2.10) Whether to keep original resource method names. Default false.