### PR TITLE
description is invalid at same level as ref

### DIFF
--- a/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/swagger.fmt
+++ b/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/swagger.fmt
@@ -300,8 +300,8 @@
 [#macro referenceDataType dataType description="" defaultType="file"]
   [#-- @ftlvariable name="dataType" type="com.webcohesion.enunciate.api.datatype.DataTypeReference" --]
   [#if dataType.value??]
-"description" : "${description?json_string}",
     [#if dataType.containers?? && dataType.containers?size > 0]
+"description" : "${description?json_string}",
       [#list dataType.containers as container]
         [#if !container.isMap()]
 "type" : "array",


### PR DESCRIPTION
Move the description field, so it is not included for ref entries.

See https://github.com/swagger-api/swagger-editor/issues/1184
