### PR TITLE
Ignore elements with @ignore javadoc

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/util/IgnoreUtils.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/IgnoreUtils.java
@@ -15,9 +15,13 @@
  */
 package com.webcohesion.enunciate.util;
 
-import com.webcohesion.enunciate.metadata.Ignore;
+import java.util.List;
 
 import javax.lang.model.element.Element;
+
+import com.webcohesion.enunciate.javac.decorations.element.DecoratedElement;
+import com.webcohesion.enunciate.javac.javadoc.JavaDoc.JavaDocTagList;
+import com.webcohesion.enunciate.metadata.Ignore;
 
 /**
  * @author Ryan Heaton
@@ -27,6 +31,13 @@ public class IgnoreUtils {
   private IgnoreUtils() {}
 
   public static boolean isIgnored(Element element) {
+    if (element instanceof DecoratedElement) {
+      List<JavaDocTagList> ignoreTags = AnnotationUtils.getJavaDocTags("ignore", (DecoratedElement<?>) element);
+      if (!ignoreTags.isEmpty()) {
+        return true;
+      }
+    }
+
     return element.getAnnotation(Ignore.class) != null;
   }
 }


### PR DESCRIPTION
There's already a mechanism to ignore classes in the Enunciate
configuration file, and a way to use the @Ignore annotation to
ignore classes / methods, but there wasn't a way to use a javadoc
tag to do the same. Until now.

Fixes stoicflame/enunciate#694.