### PR TITLE
spring_web: ResourceEntityParameter if InputStream/Reader/ServletRequest

### DIFF
--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/model/RequestMapping.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/model/RequestMapping.java
@@ -42,6 +42,8 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
+import java.io.InputStream;
+import java.io.Reader;
 import java.lang.annotation.IncompleteAnnotationException;
 import java.util.*;
 import java.util.concurrent.Callable;
@@ -178,7 +180,7 @@ public class RequestMapping extends DecoratedExecutableElement implements HasFac
         continue;
       }
 
-      if (parameterDeclaration.getAnnotation(RequestBody.class) != null) {
+      if (parameterDeclaration.getAnnotation(RequestBody.class) != null || parameterDeclaration.getAnnotation(TypeHint.class) != null && isRequestBody(parameterDeclaration.asType())) {
         entityParameter = new ResourceEntityParameter(parameterDeclaration, variableContext, context);
       }
       else {
@@ -667,4 +669,9 @@ public class RequestMapping extends DecoratedExecutableElement implements HasFac
     return roles;
   }
 
+  private boolean isRequestBody(TypeMirror parameterType) {
+    DecoratedTypeMirror<?> type = (DecoratedTypeMirror) TypeMirrorDecorator.decorate(parameterType, env);
+    return type.isInstanceOf(InputStream.class) || type.isInstanceOf(Reader.class) || type
+            .isInstanceOf("javax.servlet.ServletRequest") || type.isInstanceOf("javax.servlet.http.HttpServletRequest");
+  }
 }


### PR DESCRIPTION
I have an use case when request body is parsed manually and in order to have this method properly documented I would annotate the parameter with `@TypeHint`

These parameters types are documented [here](http://docs.spring.io/spring/docs/current/spring-framework-reference/htmlsingle/#mvc-ann-arguments).
