### PR TITLE
fix AnnotationUtils.getJavaDocTags()

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/util/AnnotationUtils.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/AnnotationUtils.java
@@ -75,7 +75,10 @@ public class AnnotationUtils {
       //include the superclass.
       TypeMirror superclass = ((TypeElement) el).getSuperclass();
       if (superclass instanceof DeclaredType) {
-        allTags.addAll(getJavaDocTags(tag, (DecoratedElement) ((DeclaredType) superclass).asElement()));
+        final Element superclassElement = ((DeclaredType) superclass).asElement();
+        if (superclassElement instanceof DecoratedElement) {
+          allTags.addAll(getJavaDocTags(tag, (DecoratedElement) superclassElement));
+        }
       }
     }
 


### PR DESCRIPTION
Unfortunately I missed that build is failing since #709 in the examples project on `Page<Person>`.