### PR TITLE
disabledByDefault modules attribute

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/EnunciateConfiguration.java
+++ b/core/src/main/java/com/webcohesion/enunciate/EnunciateConfiguration.java
@@ -44,6 +44,7 @@ public class EnunciateConfiguration {
   private File configFile;
   private FacetFilter facetFilter;
   private Map<String, String> annotationStyles;
+  private Boolean modulesEnabledByDefault;
 
   public EnunciateConfiguration() {
     this(createDefaultConfigurationSource());
@@ -366,6 +367,13 @@ public class EnunciateConfiguration {
       disabled.add(String.valueOf(warning));
     }
     return disabled;
+  }
+
+  public boolean isModulesEnabledByDefault() {
+    if (modulesEnabledByDefault == null) {
+      modulesEnabledByDefault = !source.getBoolean("modules[@disabledByDefault]", false);
+    }
+    return modulesEnabledByDefault;
   }
 
   public static final class License {

--- a/core/src/main/java/com/webcohesion/enunciate/module/BasicEnunicateModule.java
+++ b/core/src/main/java/com/webcohesion/enunciate/module/BasicEnunicateModule.java
@@ -38,11 +38,13 @@ public abstract class BasicEnunicateModule implements EnunciateModule, Depending
   protected Enunciate enunciate;
   protected EnunciateContext context;
   protected HierarchicalConfiguration config;
+  private boolean enabledByDefault;
 
   @Override
   public void init(Enunciate engine) {
     this.enunciate = engine;
     this.config = (HierarchicalConfiguration) this.enunciate.getConfiguration().getSource().subset("modules." + getName());
+    this.enabledByDefault = this.enunciate.getConfiguration().isModulesEnabledByDefault();
   }
 
   @Override
@@ -57,7 +59,11 @@ public abstract class BasicEnunicateModule implements EnunciateModule, Depending
 
   @Override
   public boolean isEnabled() {
-    return !this.config.getBoolean("[@disabled]", false);
+    return !this.config.getBoolean("[@disabled]", !isEnabledByDefault());
+  }
+
+  protected boolean isEnabledByDefault() {
+    return enabledByDefault;
   }
 
   public File resolveFile(String filePath) {

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/JacksonModule.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/JacksonModule.java
@@ -78,8 +78,8 @@ public class JacksonModule extends BasicProviderModule implements TypeDetectingM
   }
 
   @Override
-  public boolean isEnabled() {
-    return !this.config.getBoolean("[@disabled]", !jacksonDetected);
+  protected boolean isEnabledByDefault() {
+    return jacksonDetected && super.isEnabledByDefault();
   }
 
   public boolean isDisableExamples() {

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/Jackson1Module.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/Jackson1Module.java
@@ -112,8 +112,8 @@ public class Jackson1Module extends BasicProviderModule implements TypeDetecting
   }
 
   @Override
-  public boolean isEnabled() {
-    return !this.config.getBoolean("[@disabled]", !jacksonDetected);
+  protected boolean isEnabledByDefault() {
+    return jacksonDetected && super.isEnabledByDefault();
   }
 
   public DataTypeDetectionStrategy getDataTypeDetectionStrategy() {

--- a/top/src/main/resources/META-INF/enunciate-2.10.0.xsd
+++ b/top/src/main/resources/META-INF/enunciate-2.10.0.xsd
@@ -345,6 +345,7 @@
       <xs:element name="idl" type="module-idl" minOccurs="0" maxOccurs="1"/>
       <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
     </xs:sequence>
+    <xs:attribute name="disabledByDefault" type="xs:boolean"/>
   </xs:complexType>
 
   <xs:complexType name="module-idl">


### PR DESCRIPTION
At implementation for #688 

- `enabledByDefault` attribute for modules
- `enabled` attribute for each module

So the usage looks like this:

```xml
<modules enabledByDefault="false">
  <jaxrs enabled="true"/>
  <jackson enabled="true"/>
  <docs enabled="true"/>
  <swagger enabled="true"/>
</modules>
```

WDYT?