### PR TITLE
Scrub '*' from slug resource labels for path based grouping for spring-web

### DIFF
--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/PathBasedResourceGroupImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/PathBasedResourceGroupImpl.java
@@ -128,7 +128,7 @@ public class PathBasedResourceGroupImpl implements ResourceGroup {
   }
 
   private static String scrubPathForSlug(String facetValue) {
-    return facetValue.replace('/', '_').replace(':', '_').replace('{', '_').replace('}', '_');
+    return facetValue.replace('/', '_').replace(':', '_').replace('{', '_').replace('}', '_').replace('*', '_');
   }
 
   @Override


### PR DESCRIPTION
This bug happens when using a wildcard path in a spring-web controller with path based grouping. 

The slug generated for the resource html file is based on the path. However, the * is not replaced in the file name. This is fine on macos and linux, but causes a problem on windows specifically when using the enunciate-maven-plugin.

ie 
```
@RequestMapping("/foo/**")
```

generates a file name of resource_foo_\*\*.html