### PR TITLE
Mark resource page elements as deprecated transitively too.

### DIFF
--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ResourceImpl.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/api/impl/ResourceImpl.java
@@ -76,7 +76,11 @@ public class ResourceImpl implements Resource {
 
   @Override
   public String getDeprecated() {
-    return ElementUtils.findDeprecationMessage(this.resourceMethod);
+    String message = ElementUtils.findDeprecationMessage(this.resourceMethod);
+    if (message == null) {
+      message = ElementUtils.findDeprecationMessage(this.resourceMethod.getParent());
+    }
+    return message;
   }
 
   @Override

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ResourceImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/ResourceImpl.java
@@ -76,7 +76,11 @@ public class ResourceImpl implements Resource {
 
   @Override
   public String getDeprecated() {
-    return ElementUtils.findDeprecationMessage(this.requestMapping);
+    String message = ElementUtils.findDeprecationMessage(this.requestMapping);
+    if (message == null) {
+      message = ElementUtils.findDeprecationMessage(this.requestMapping.getParent());
+    }
+    return message;
   }
 
   @Override


### PR DESCRIPTION
For #749, this adds a missing component so that the resources page will properly get marked deprecated when all methods are marked deprecated directly or transitively.