### PR TITLE
Add methods used by swagger/openapi backend to Property interface

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/api/datatype/DataType.java
+++ b/core/src/main/java/com/webcohesion/enunciate/api/datatype/DataType.java
@@ -69,4 +69,6 @@ public interface DataType extends HasStyles, HasAnnotations, HasFacets {
   JavaDoc getJavaDoc();
 
   Element getJavaElement();
+  
+  String getXmlName();
 }

--- a/core/src/main/java/com/webcohesion/enunciate/api/datatype/Property.java
+++ b/core/src/main/java/com/webcohesion/enunciate/api/datatype/Property.java
@@ -40,4 +40,8 @@ public interface Property extends HasStyles, HasAnnotations, HasFacets {
   JavaDoc getJavaDoc();
 
   String getSince();
+  
+  PropertyMetadata getMetadata();
+  
+  boolean isAttribute();
 }

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/DataTypeImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/DataTypeImpl.java
@@ -197,4 +197,9 @@ public abstract class DataTypeImpl implements DataType {
   public Element getJavaElement() {
     return this.typeDefinition;
   }
+  
+  @Override
+  public String getXmlName() {
+	  return null;
+  }
 }

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/PropertyImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/PropertyImpl.java
@@ -19,6 +19,7 @@ import com.webcohesion.enunciate.api.ApiRegistrationContext;
 import com.webcohesion.enunciate.api.Styles;
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
 import com.webcohesion.enunciate.api.datatype.Property;
+import com.webcohesion.enunciate.api.datatype.PropertyMetadata;
 import com.webcohesion.enunciate.facets.Facet;
 import com.webcohesion.enunciate.javac.decorations.element.ElementUtils;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
@@ -118,5 +119,15 @@ public class PropertyImpl implements Property {
   public String getSince() {
     JavaDoc.JavaDocTagList sinceTags = getJavaDoc().get("since");
     return sinceTags == null ? null : sinceTags.toString();
+  }
+
+  @Override
+  public PropertyMetadata getMetadata() {
+	  return null;
+  }
+
+  @Override
+  public boolean isAttribute() {
+	return false;
   }
 }

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/TypeReferencePropertyImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/TypeReferencePropertyImpl.java
@@ -8,6 +8,7 @@ import javax.lang.model.element.AnnotationMirror;
 
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
 import com.webcohesion.enunciate.api.datatype.Property;
+import com.webcohesion.enunciate.api.datatype.PropertyMetadata;
 import com.webcohesion.enunciate.facets.Facet;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.modules.jackson.model.types.KnownJsonType;
@@ -85,5 +86,15 @@ public class TypeReferencePropertyImpl implements Property {
   @Override
   public String getSince() {
     return null;
+  }
+  
+  @Override
+  public PropertyMetadata getMetadata() {
+	  return null;
+  }
+
+  @Override
+  public boolean isAttribute() {
+	return false;
   }
 }

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/DataTypeImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/DataTypeImpl.java
@@ -197,4 +197,9 @@ public abstract class DataTypeImpl implements DataType {
   public Element getJavaElement() {
     return this.typeDefinition;
   }
+  
+  @Override
+  public String getXmlName() {
+	  return null;
+  }
 }

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/PropertyImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/PropertyImpl.java
@@ -19,6 +19,7 @@ import com.webcohesion.enunciate.api.ApiRegistrationContext;
 import com.webcohesion.enunciate.api.Styles;
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
 import com.webcohesion.enunciate.api.datatype.Property;
+import com.webcohesion.enunciate.api.datatype.PropertyMetadata;
 import com.webcohesion.enunciate.facets.Facet;
 import com.webcohesion.enunciate.javac.decorations.element.ElementUtils;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
@@ -118,5 +119,15 @@ public class PropertyImpl implements Property {
   public String getSince() {
     JavaDoc.JavaDocTagList sinceTags = getJavaDoc().get("since");
     return sinceTags == null ? null : sinceTags.toString();
+  }
+  
+  @Override
+  public PropertyMetadata getMetadata() {
+	  return null;
+  }
+
+  @Override
+  public boolean isAttribute() {
+	return false;
   }
 }

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/TypeReferencePropertyImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/TypeReferencePropertyImpl.java
@@ -8,6 +8,7 @@ import javax.lang.model.element.AnnotationMirror;
 
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
 import com.webcohesion.enunciate.api.datatype.Property;
+import com.webcohesion.enunciate.api.datatype.PropertyMetadata;
 import com.webcohesion.enunciate.facets.Facet;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.modules.jackson1.model.types.KnownJsonType;
@@ -85,5 +86,15 @@ public class TypeReferencePropertyImpl implements Property {
   @Override
   public String getSince() {
     return null;
+  }
+
+  @Override
+  public PropertyMetadata getMetadata() {
+	  return null;
+  }
+
+  @Override
+  public boolean isAttribute() {
+	return false;
   }
 }

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/ComplexDataTypeImpl.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/ComplexDataTypeImpl.java
@@ -108,6 +108,7 @@ public class ComplexDataTypeImpl extends DataTypeImpl {
     return properties;
   }
 
+  @Override
   public String getXmlName() {
     ElementDeclaration elementDeclaration = this.typeDefinition.getContext().findElementDeclaration(this.typeDefinition);
     String xmlName = null;

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/EnumDataTypeImpl.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/EnumDataTypeImpl.java
@@ -74,4 +74,9 @@ public class EnumDataTypeImpl extends DataTypeImpl {
   public Map<String, String> getPropertyMetadata() {
     return Collections.emptyMap();
   }
+  
+  @Override
+  public String getXmlName() {
+	  return null;
+  }
 }

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/PropertyImpl.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/PropertyImpl.java
@@ -61,7 +61,8 @@ public class PropertyImpl implements Property {
     return this.accessor.isAttribute() ? "attribute" : this.accessor.isValue() ? "(value)" : "element";
   }
 
-  public PropertyMetadata getNamespaceInfo() {
+  @Override
+  public PropertyMetadata getMetadata() {
     return new PropertyMetadata(getNamespacePrefix(), getNamespace(), null);
   }
 
@@ -146,6 +147,7 @@ public class PropertyImpl implements Property {
     return description;
   }
 
+  @Override
   public boolean isAttribute() {
     return this.accessor.isAttribute();
   }


### PR DESCRIPTION
Swagger backend references methods in the jaxb module which are
not exposed by the Java API.
I guess it works because freemarker uses reflection on the provided
beans to make calls.

In the OpenAPI backend I have moved some logic from the freemarker
template into Java classes. So I need the calls to be exposed via
the proper interfaces.