### PR TITLE
Add support for spring web @PathVariable required element 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <rxjava.version>1.1.5</rxjava.version>
     <slf4j.version>1.7.5</slf4j.version>
     <servlet-api.version>3.0.1</servlet-api.version>
-    <spring-web.version>4.2.2.RELEASE</spring-web.version>
+    <spring-web.version>4.3.9.RELEASE</spring-web.version>
     <swagger-annotations.version>1.5.9</swagger-annotations.version>
     <validation-api.version>1.1.0.Final</validation-api.version>
 

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/model/SimpleRequestParameter.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/model/SimpleRequestParameter.java
@@ -106,7 +106,7 @@ public class SimpleRequestParameter extends RequestParameter {
 
     PathVariable pathParam = declaration.getAnnotation(PathVariable.class);
     if (pathParam != null) {
-      required = true;
+      required = pathParam.required();
       parameterName = pathParam.value();
       if (parameterName.isEmpty()) {
         parameterName = declaration.getSimpleName().toString();

--- a/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/swagger.fmt
+++ b/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/swagger.fmt
@@ -215,8 +215,11 @@
           {
             "name" : "${parameter.name}",
             "in" : "${parameter.typeLabel}",
-                    [#if parameter.typeLabel = "path"]
-            "required" : true,
+                    [#if (parameter.typeLabel == "path"
+                        || parameter.typeLabel == "query"
+                        || parameter.typeLabel == "formData"
+                        || parameter.typeLabel == "header") && parameter.constraints?? && parameter.constraints?contains("required")]
+            "required" :
                     [/#if]
                     [#if parameter.defaultValue??]
             "default" : "${parameter.defaultValue}",


### PR DESCRIPTION
Since 4.3.3, Spring web add `required` to `@PathVariable` annotation. 

Currently, `required` is not correctly set to true in swagger ui because it is set to true only if parameter is of `path` type in swagger ui template. Enunciate spring web has handled these annotations
- MatrixVariable
- RequestParam
- PathVariable
- RequestPart

`required` has been added into parameter `constraints` field.

