### PR TITLE
jackson: process @TypeHint when collecting referenced types

### DIFF
--- a/docs/src/test/java/com/webcohesion/enunciate/modules/docs/FileExists.java
+++ b/docs/src/test/java/com/webcohesion/enunciate/modules/docs/FileExists.java
@@ -1,0 +1,18 @@
+package com.webcohesion.enunciate.modules.docs;
+
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+
+import java.io.File;
+
+class FileExists extends TypeSafeMatcher<File> {
+  @Override
+  protected boolean matchesSafely(File item) {
+    return item.exists();
+  }
+
+  @Override
+  public void describeTo(Description description) {
+    description.appendText("exists");
+  }
+}

--- a/docs/src/test/java/com/webcohesion/enunciate/modules/docs/TestDocsModule.java
+++ b/docs/src/test/java/com/webcohesion/enunciate/modules/docs/TestDocsModule.java
@@ -12,6 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.assertThat;
+
 public class TestDocsModule extends TestCase {
     public void testFoo() throws Exception {
         Properties testProperties = new Properties();
@@ -49,8 +52,10 @@ public class TestDocsModule extends TestCase {
 
         engine.run();
 
-        File enumFile = new File("target/docs/json_CountEnum.html");
-        assertTrue(enumFile.exists());
+        File docsDir = new File("target/docs");
+
+        File enumFile = new File(docsDir, "json_CountEnum.html");
+        assertThat(enumFile, exists());
 
         FileReader fr = new FileReader(enumFile);
         BufferedReader br = new BufferedReader(fr);
@@ -67,8 +72,12 @@ public class TestDocsModule extends TestCase {
         }
         assertEquals(CountEnum.values().length, count);
 
-        File downloadFile = new File("target/docs/downloads.html");
-        assertTrue(downloadFile.exists());
+        assertThat(new File(docsDir, "json_TypeWithHintOnProperty.html"), exists());
+        assertThat(new File(docsDir, "json_PropertyTypeActual.html"), not(exists()));
+        assertThat(new File(docsDir, "json_PropertyTypeHint.html"), exists());
+
+        File downloadFile = new File(docsDir, "downloads.html");
+        assertThat(downloadFile, exists());
 
         fr = new FileReader(downloadFile);
         br = new BufferedReader(fr);
@@ -84,5 +93,9 @@ public class TestDocsModule extends TestCase {
             br.close();
         }
         assertEquals(0, count);
+    }
+
+    private static FileExists exists() {
+        return new FileExists();
     }
 }

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/PropertyTypeActual.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/PropertyTypeActual.java
@@ -1,0 +1,4 @@
+package com.webcohesion.enunciate.samples.docs;
+
+public class PropertyTypeActual {
+}

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/PropertyTypeHint.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/PropertyTypeHint.java
@@ -1,0 +1,4 @@
+package com.webcohesion.enunciate.samples.docs;
+
+public class PropertyTypeHint {
+}

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/TypeWithHintOnProperty.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/TypeWithHintOnProperty.java
@@ -1,0 +1,10 @@
+package com.webcohesion.enunciate.samples.docs;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.webcohesion.enunciate.metadata.rs.TypeHint;
+
+@JsonInclude
+public class TypeWithHintOnProperty {
+  @TypeHint(PropertyTypeHint.class)
+  public PropertyTypeActual someProperty;
+}

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
@@ -27,6 +27,7 @@ import com.webcohesion.enunciate.javac.decorations.type.DecoratedTypeMirror;
 import com.webcohesion.enunciate.javac.decorations.type.TypeMirrorUtils;
 import com.webcohesion.enunciate.metadata.json.JsonSeeAlso;
 import com.webcohesion.enunciate.metadata.qname.XmlQNameEnum;
+import com.webcohesion.enunciate.metadata.rs.TypeHint;
 import com.webcohesion.enunciate.module.EnunciateModuleContext;
 import com.webcohesion.enunciate.modules.jackson.javac.InterfaceJacksonDeclaredType;
 import com.webcohesion.enunciate.modules.jackson.javac.ParameterizedJacksonDeclaredType;
@@ -39,6 +40,7 @@ import com.webcohesion.enunciate.modules.jackson.model.util.JacksonUtil;
 import com.webcohesion.enunciate.modules.jackson.model.util.MapType;
 import com.webcohesion.enunciate.util.IgnoreUtils;
 import com.webcohesion.enunciate.util.OneTimeLogMessage;
+import com.webcohesion.enunciate.util.TypeHintUtils;
 
 import javax.activation.DataHandler;
 import javax.lang.model.element.Element;
@@ -335,7 +337,16 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
         addSeeAlsoTypeDefinitions(typeDef, stack);
 
         for (Member member : typeDef.getMembers()) {
-          addReferencedTypeDefinitions(member, stack);
+          TypeHint hintInfo = member.getAnnotation(TypeHint.class);
+          if (hintInfo != null) {
+            TypeMirror hint = TypeHintUtils.getTypeHint(hintInfo, context.getProcessingEnvironment(), null);
+            if (hint != null) {
+              addReferencedTypeDefinitions(hint, stack);
+            }
+          }
+          else {
+            addReferencedTypeDefinitions(member, stack);
+          }
         }
 
         Value value = typeDef.getValue();

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/EnunciateJackson1Context.java
@@ -22,6 +22,7 @@ import com.webcohesion.enunciate.javac.decorations.type.DecoratedTypeMirror;
 import com.webcohesion.enunciate.javac.decorations.type.TypeMirrorUtils;
 import com.webcohesion.enunciate.metadata.json.JsonSeeAlso;
 import com.webcohesion.enunciate.metadata.qname.XmlQNameEnum;
+import com.webcohesion.enunciate.metadata.rs.TypeHint;
 import com.webcohesion.enunciate.module.EnunciateModuleContext;
 import com.webcohesion.enunciate.modules.jackson1.javac.InterfaceJackson1DeclaredType;
 import com.webcohesion.enunciate.modules.jackson1.javac.ParameterizedJackson1DeclaredType;
@@ -34,6 +35,7 @@ import com.webcohesion.enunciate.modules.jackson1.model.util.JacksonUtil;
 import com.webcohesion.enunciate.modules.jackson1.model.util.MapType;
 import com.webcohesion.enunciate.util.IgnoreUtils;
 import com.webcohesion.enunciate.util.OneTimeLogMessage;
+import com.webcohesion.enunciate.util.TypeHintUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonSubTypes;
@@ -322,7 +324,16 @@ public class EnunciateJackson1Context extends EnunciateModuleContext {
         addSeeAlsoTypeDefinitions(typeDef, stack);
 
         for (Member member : typeDef.getMembers()) {
-          addReferencedTypeDefinitions(member, stack);
+          TypeHint hintInfo = member.getAnnotation(TypeHint.class);
+          if (hintInfo != null) {
+            TypeMirror hint = TypeHintUtils.getTypeHint(hintInfo, context.getProcessingEnvironment(), null);
+            if (hint != null) {
+              addReferencedTypeDefinitions(hint, stack);
+            }
+          }
+          else {
+            addReferencedTypeDefinitions(member, stack);
+          }
         }
 
         Value value = typeDef.getValue();


### PR DESCRIPTION
When a member is annotated with `@TypeHint` that type should be referenced, not the actual one.

I would like to have a test for it, so added these checks to `TestDocsModule`, that's probably not the best place - can you suggest a better approach?