### PR TITLE
maven: MojoFailureException if specified configFile does not exist

### DIFF
--- a/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/AssembleBaseMojo.java
+++ b/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/AssembleBaseMojo.java
@@ -22,6 +22,7 @@ import com.webcohesion.enunciate.module.DocumentationProviderModule;
 import com.webcohesion.enunciate.module.EnunciateModule;
 import com.webcohesion.enunciate.module.WebInfAwareModule;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -88,7 +89,7 @@ public class AssembleBaseMojo extends ConfigMojo {
   }
 
   @Override
-  public void execute() throws MojoExecutionException {
+  public void execute() throws MojoExecutionException, MojoFailureException {
     if (skipEnunciate) {
       getLog().info("Skipping enunciate per configuration.");
       return;

--- a/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/ConfigMojo.java
+++ b/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/ConfigMojo.java
@@ -48,6 +48,7 @@ import org.apache.maven.model.Plugin;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
@@ -208,7 +209,7 @@ public class ConfigMojo extends AbstractMojo {
   @Parameter ( name = "sources" )
   protected String[] sources;
 
-  public void execute() throws MojoExecutionException {
+  public void execute() throws MojoExecutionException, MojoFailureException {
     if (skipEnunciate) {
       getLog().info("[ENUNCIATE] Skipping enunciate per configuration.");
       return;
@@ -239,6 +240,12 @@ public class ConfigMojo extends AbstractMojo {
       catch (Exception e) {
         throw new MojoExecutionException("Problem with enunciate config file " + configFile, e);
       }
+    }
+    else if (this.configFile != null) {
+      throw new MojoFailureException("Enunciate config file \"" + this.configFile + "\" does not exist");
+    }
+    else {
+      getLog().debug("[ENUNCIATE] Default config file does not exist");
     }
 
     //set the default configured label.

--- a/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/DocsBaseMojo.java
+++ b/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/DocsBaseMojo.java
@@ -19,6 +19,7 @@ import com.webcohesion.enunciate.Enunciate;
 import com.webcohesion.enunciate.module.DocumentationProviderModule;
 import com.webcohesion.enunciate.module.EnunciateModule;
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -91,7 +92,7 @@ public class DocsBaseMojo extends ConfigMojo implements MavenReport {
   }
 
   @Override
-  public void execute() throws MojoExecutionException {
+  public void execute() throws MojoExecutionException, MojoFailureException {
     //if this method is called, it means we're _not_ being invoked via the maven site plugin. Therefore, we don't need a staging area:
     this.docsStagingDir = docsDir;
 


### PR DESCRIPTION
If this property is configured but the file does not exists (most likely because of a typo) - it's much better to fail the build instead of silently using default configuration.