### PR TITLE
jackson: ignore properties of enum type

### DIFF
--- a/docs/src/test/java/com/webcohesion/enunciate/modules/docs/TestDocsModule.java
+++ b/docs/src/test/java/com/webcohesion/enunciate/modules/docs/TestDocsModule.java
@@ -72,6 +72,8 @@ public class TestDocsModule extends TestCase {
         }
         assertEquals(CountEnum.values().length, count);
 
+        assertThat(new File(docsDir, "json_OtherEnum.html"), not(exists()));
+
         assertThat(new File(docsDir, "json_TypeWithHintOnProperty.html"), exists());
         assertThat(new File(docsDir, "json_PropertyTypeActual.html"), not(exists()));
         assertThat(new File(docsDir, "json_PropertyTypeHint.html"), exists());

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/CountEnum.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/CountEnum.java
@@ -20,5 +20,7 @@ public enum CountEnum {
     /**
      * <p>Here is an enum for a value that comes third.</p>
      */
-    THIRD,
+    THIRD;
+
+    public final OtherEnum otherEnum = OtherEnum.VALUE;
 }

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/OtherEnum.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/OtherEnum.java
@@ -1,0 +1,5 @@
+package com.webcohesion.enunciate.samples.docs;
+
+public enum OtherEnum {
+    VALUE
+}

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
@@ -26,6 +26,7 @@ import com.webcohesion.enunciate.metadata.ClientName;
 import com.webcohesion.enunciate.modules.jackson.EnunciateJacksonContext;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -141,6 +142,9 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
    * @return the potential accessors for this type definition.
    */
   protected List<javax.lang.model.element.Element> loadPotentialAccessors(AccessorFilter filter) {
+    if (getKind() == ElementKind.ENUM) {
+      return Collections.emptyList(); // ignore properties if enum
+    }
     List<VariableElement> potentialFields = new ArrayList<VariableElement>();
     List<PropertyElement> potentialProperties = new ArrayList<PropertyElement>();
     aggregatePotentialAccessors(potentialFields, potentialProperties, this, filter, this.context.isCollapseTypeHierarchy());

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
@@ -26,6 +26,7 @@ import com.webcohesion.enunciate.modules.jackson1.EnunciateJackson1Context;
 import org.codehaus.jackson.annotate.*;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -141,6 +142,9 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
    * @return the potential accessors for this type definition.
    */
   protected List<javax.lang.model.element.Element> loadPotentialAccessors(AccessorFilter filter) {
+    if (getKind() == ElementKind.ENUM) {
+      return Collections.emptyList(); // ignore properties if enum
+    }
     List<VariableElement> potentialFields = new ArrayList<VariableElement>();
     List<PropertyElement> potentialProperties = new ArrayList<PropertyElement>();
     aggregatePotentialAccessors(potentialFields, potentialProperties, this, filter, this.context.isCollapseTypeHierarchy());


### PR DESCRIPTION
`enum` is usually serialized as string or number, so there is no need processing its references to other types 