### PR TITLE
jackson: check @TypeHint first

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeFactory.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeFactory.java
@@ -55,6 +55,14 @@ public class JsonTypeFactory {
 
     if (adaptable instanceof Accessor) {
       Accessor accessor = (Accessor) adaptable;
+      TypeHint typeHint = accessor.getAnnotation(TypeHint.class);
+      if (typeHint != null) {
+        TypeMirror hint = TypeHintUtils.getTypeHint(typeHint, context.getContext().getProcessingEnvironment(), null);
+        if (hint != null) {
+          return getJsonType(hint, context);
+        }
+      }
+
       JsonFormat format = accessor.getAnnotation(JsonFormat.class);
       if (format != null) {
         switch (format.shape()) {
@@ -75,14 +83,6 @@ public class JsonTypeFactory {
           case ANY:
           default:
             //fall through...
-        }
-      }
-
-      TypeHint typeHint = accessor.getAnnotation(TypeHint.class);
-      if (typeHint != null) {
-        TypeMirror hint = TypeHintUtils.getTypeHint(typeHint, context.getContext().getProcessingEnvironment(), null);
-        if (hint != null) {
-          return getJsonType(hint, context);
         }
       }
 


### PR DESCRIPTION
I have a case with both `@TypeHint` and `@JsonFormat`, obviously for documentation purposes `@TypeHint` should be consulted first.

In jackson1 there is no `@JsonFormat` and `@TypeHint` is already checked first.