### PR TITLE
850 for a class the @JsonTypeInfo is now resolved also from super-classes

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
@@ -24,6 +24,7 @@ import com.webcohesion.enunciate.javac.decorations.element.*;
 import com.webcohesion.enunciate.javac.decorations.type.TypeMirrorUtils;
 import com.webcohesion.enunciate.metadata.ClientName;
 import com.webcohesion.enunciate.modules.jackson.EnunciateJacksonContext;
+import com.webcohesion.enunciate.util.AnnotationUtils;
 import com.webcohesion.enunciate.util.SortedList;
 
 import javax.lang.model.element.*;
@@ -497,7 +498,9 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
   public String getTypeIdProperty() {
     String property = null;
 
-    JsonTypeInfo typeInfo = getAnnotation(JsonTypeInfo.class);
+    List<JsonTypeInfo> annotations = AnnotationUtils.getAnnotations(JsonTypeInfo.class, this);
+    JsonTypeInfo typeInfo = annotations.isEmpty() ? null : annotations.get(0);
+
     if (typeInfo != null) {
       property = typeInfo.property();
       if ("".equals(property)) {

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
@@ -23,6 +23,7 @@ import com.webcohesion.enunciate.javac.decorations.element.*;
 import com.webcohesion.enunciate.javac.decorations.type.TypeMirrorUtils;
 import com.webcohesion.enunciate.metadata.ClientName;
 import com.webcohesion.enunciate.modules.jackson1.EnunciateJackson1Context;
+import com.webcohesion.enunciate.util.AnnotationUtils;
 import com.webcohesion.enunciate.util.SortedList;
 import org.codehaus.jackson.annotate.*;
 
@@ -482,7 +483,9 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
   public String getTypeIdProperty() {
     String property = null;
 
-    JsonTypeInfo typeInfo = getAnnotation(JsonTypeInfo.class);
+    List<JsonTypeInfo> annotations = AnnotationUtils.getAnnotations(JsonTypeInfo.class, this);
+    JsonTypeInfo typeInfo = annotations.isEmpty() ? null : annotations.get(0);
+
     if (typeInfo != null) {
       property = typeInfo.property();
       if ("".equals(property)) {


### PR DESCRIPTION
fixes #850 (and #636 )

@stoicflame in `com.webcohesion.enunciate.modules.jackson1.api.impl.DataTypeExampleImpl#findSpecifiedTypeInfoValue` the `@JsonSubType` information is evaluated, but not for the type-hierarchy, only the current class (`type.getAnnotation(JsonSubTypes.class)`). i am not sure, but i think, that also here the annotations of super-types must be considered. what do you think?