### PR TITLE
improvements to fix #655

### DIFF
--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/Operation.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/Operation.java
@@ -1,0 +1,17 @@
+package com.webcohesion.enunciate.samples.docs;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "operationType")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = OperationA.class, name = "A"),
+        @JsonSubTypes.Type(value = OperationB.class, name = "B")})
+public abstract class Operation {
+  public enum OperationType {
+    A,
+    B
+  }
+
+  public OperationType operationType;
+}

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/OperationA.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/OperationA.java
@@ -1,0 +1,5 @@
+package com.webcohesion.enunciate.samples.docs;
+
+public class OperationA extends Operation {
+  public boolean a;
+}

--- a/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/OperationB.java
+++ b/docs/src/test/samples/com/webcohesion/enunciate/samples/docs/OperationB.java
@@ -1,0 +1,5 @@
+package com.webcohesion.enunciate.samples.docs;
+
+public class OperationB extends Operation {
+  public boolean b;
+}

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/DataTypeExampleImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/DataTypeExampleImpl.java
@@ -130,6 +130,10 @@ public class DataTypeExampleImpl extends ExampleImpl {
 
     FacetFilter facetFilter = type.getContext().getContext().getConfiguration().getFacetFilter();
     for (Member member : type.getMembers()) {
+      if (node.has(member.getName())) {
+        continue;
+      }
+
       if (!facetFilter.accept(member)) {
         continue;
       }

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/ObjectDataTypeImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/ObjectDataTypeImpl.java
@@ -79,7 +79,8 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
 
     if (this.typeDefinition.getTypeIdInclusion() == JsonTypeInfo.As.PROPERTY) {
       properties = new ArrayList<Property>(members.size() + 1);
-      if (this.typeDefinition.getTypeIdProperty() != null) {
+      if (this.typeDefinition.getTypeIdProperty() != null
+              && members.stream().noneMatch(m -> this.typeDefinition.getTypeIdProperty().equals(m.getName()))) {
         properties.add(new TypeReferencePropertyImpl(this.typeDefinition.getTypeIdProperty()));
       }
     }

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
@@ -493,7 +493,10 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
       }
     }
     JsonTypeName typeName = getAnnotation(JsonTypeName.class);
-    return typeName != null && !typeName.value().isEmpty() ? typeName.value() : getSimpleName().toString();
+    if (typeName != null && !typeName.value().isEmpty()) {
+      return typeName.value();
+    }
+    return isAbstract() ? "..." : getSimpleName().toString();
   }
 
   public String[] getPropertyOrder() {

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/DataTypeExampleImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/DataTypeExampleImpl.java
@@ -125,6 +125,10 @@ public class DataTypeExampleImpl extends ExampleImpl {
 
     FacetFilter facetFilter = type.getContext().getContext().getConfiguration().getFacetFilter();
     for (Member member : type.getMembers()) {
+      if (node.has(member.getName())) {
+        continue;
+      }
+
       if (!facetFilter.accept(member)) {
         continue;
       }

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/ObjectDataTypeImpl.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/api/impl/ObjectDataTypeImpl.java
@@ -79,7 +79,8 @@ public class ObjectDataTypeImpl extends DataTypeImpl {
 
     if (this.typeDefinition.getTypeIdInclusion() == JsonTypeInfo.As.PROPERTY) {
       properties = new ArrayList<Property>(members.size() + 1);
-      if (this.typeDefinition.getTypeIdProperty() != null) {
+      if (this.typeDefinition.getTypeIdProperty() != null
+              && members.stream().noneMatch(m -> this.typeDefinition.getTypeIdProperty().equals(m.getName()))) {
         properties.add(new TypeReferencePropertyImpl(this.typeDefinition.getTypeIdProperty()));
       }
     }

--- a/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
+++ b/jackson1/src/main/java/com/webcohesion/enunciate/modules/jackson1/model/TypeDefinition.java
@@ -478,7 +478,10 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
       }
     }
     JsonTypeName typeName = getAnnotation(JsonTypeName.class);
-    return typeName != null && !typeName.value().isEmpty() ? typeName.value() : getSimpleName().toString();
+    if (typeName != null && !typeName.value().isEmpty()) {
+      return typeName.value();
+    }
+    return isAbstract() ? "..." : getSimpleName().toString();
   }
 
   public String[] getPropOrder() {


### PR DESCRIPTION
- skip TypeReferencePropertyImpl if property is explicitly defined
- in example keep property value detected from `@JsonSubTypes` (which is put there in the previous #857)