### PR TITLE
Upgraded Jackson2 dependency to 2.9.5

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/AccessorVisibilityChecker.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/AccessorVisibilityChecker.java
@@ -17,11 +17,24 @@ import com.fasterxml.jackson.databind.introspect.VisibilityChecker;
  *
  * @author Martin Kacer
  */
+@JsonAutoDetect(
+        getterVisibility = Visibility.PUBLIC_ONLY,
+        isGetterVisibility = Visibility.PUBLIC_ONLY,
+        setterVisibility = Visibility.ANY,
+        /**
+         * By default, all matching single-arg constructed are found,
+         * regardless of visibility. Does not apply to factory methods,
+         * they can not be auto-detected; ditto for multiple-argument
+         * constructors.
+        */
+        creatorVisibility = Visibility.ANY,
+        fieldVisibility = Visibility.PUBLIC_ONLY
+)
 public class AccessorVisibilityChecker {
   
   private final Map<PropertyAccessor,Visibility> minLevels;
   
-  public static final JsonAutoDetect DEFAULT_VISIBILITY = VisibilityChecker.Std.class.getAnnotation(JsonAutoDetect.class);
+  public static final JsonAutoDetect DEFAULT_VISIBILITY = AccessorVisibilityChecker.class.getAnnotation(JsonAutoDetect.class);
   public static final AccessorVisibilityChecker DEFAULT_CHECKER = new AccessorVisibilityChecker(DEFAULT_VISIBILITY);
 
   private AccessorVisibilityChecker(Map<PropertyAccessor,Visibility> minLevels) {

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <gwt.version>2.7.0</gwt.version>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson1.version>1.9.13</jackson1.version>
-    <jackson2.version>2.5.3</jackson2.version>
+    <jackson2.version>2.9.5</jackson2.version>
     <jaxb.version>2.2.11</jaxb.version>
     <jaxws-tools.version>2.3.0</jaxws-tools.version>
     <jaxrs-api.version>2.0.1</jaxrs-api.version>


### PR DESCRIPTION
- Added @JsonAutoDetect to AccessorVisibilityChecker because the VisibilityChecker.Std class does not provide such an annotation anymore
- Use @JsonAutoDetect specified on AccessorVisibilityChecker for DEFAULT_VISIBILITY constant