### PR TITLE
Extract XmlRootElement@name for Enum types (fixes #894)

### DIFF
--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/EnumDataTypeImpl.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/api/impl/EnumDataTypeImpl.java
@@ -82,6 +82,10 @@ public class EnumDataTypeImpl extends DataTypeImpl {
             enumValue.getFacets());
   }
 
+  public String getXmlName() {
+	return this.typeDefinition.getXmlName();
+  }
+
   @Override
   public Property findProperty(String name) {
     return null;

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/model/EnumTypeDefinition.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/model/EnumTypeDefinition.java
@@ -125,4 +125,14 @@ public class EnumTypeDefinition extends SimpleTypeDefinition {
     return getAnnotation(XmlJavaTypeAdapter.class) == null;
   }
 
+  public String getXmlName() {
+    ElementDeclaration elementDeclaration = getContext().findElementDeclaration(this.delegate);
+    String xmlName = null;
+    if (elementDeclaration != null) {
+      xmlName = elementDeclaration.getName();
+    }
+    return xmlName;
+  }
+  
+
 }


### PR DESCRIPTION
This is basically a copy of the code in ComplexTypeDefinition.

With this, I can see the Enum's proper wire name in the OpenAPI backend.
