### PR TITLE
Fix for php_xml_client with issues when attempting to skip unknown elements

### DIFF
--- a/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
+++ b/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
@@ -229,8 +229,8 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     //no-op: skip any insignificant whitespace, comments, etc.
                 }
                 else if (!$xml->isEmptyElement && !$this->setKnownChildElement($xml)) {
-                    $n = $xml->localName;
-                    $ns = $xml->namespaceURI;
+                    $n = empty($xml->localName) ? NULL : $xml->localName;
+                    $ns = empty($xml->namespaceURI) ? NULL : $xml->namespaceURI;
       [#if type.anyElement??]
                     $dom = new \DOMDocument();
                     $nodeFactory = $dom;
@@ -248,7 +248,7 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     $dom = $e;
 
                     //create any child elements...
-                    while ($xml->read() && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName != $n && $xml->namespaceURI != $ns) {
+                    while ($xml->read() && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns) {
                         if ($xml->nodeType == \XMLReader::ELEMENT) {
                             $e = $nodeFactory->createElementNS($xml->namespaceURI, $xml->localName);
                             $dom->appendChild($e);
@@ -271,7 +271,7 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     array_push($this->${type.anyElement.clientSimpleName}, $nodeFactory);
       [#else]
                     //skip the unknown element
-                    while ($xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName != $n && $xml->namespaceURI != $ns) {
+                    while ($xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns) {
                         $xml->read();
                     }
       [/#if]

--- a/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
+++ b/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
@@ -271,9 +271,7 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     array_push($this->${type.anyElement.clientSimpleName}, $nodeFactory);
       [#else]
                     //skip the unknown element
-                    while ($xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns) {
-                        $xml->read();
-                    }
+                    while ($xml->read && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns);
       [/#if]
                 }
                 $xml->read(); //advance the reader.


### PR DESCRIPTION
Consider the following piece of XML where `<number>` is unknown to the PHP client model generated by enunciate.

```
<tracks>
  <track>
    <title>test 1</title> <!-- known to the model -->
    <number>1</number> <!-- unknown to the model -->
  </track>
  <track>
    <title>test 2</title> <!-- known to the model -->
    <number>2</number> <! -- unknown to the model -->
  </track>
</track>
```

What happens is that the XMLReader starts processing `<tracks>`, `<track>` and `<title>`. Arriving at `<number>` the following condition fails : 

`!$xml->isEmptyElement && !$this->setKnownChildElement($xml)`

`<number>` is not a known child element.

Next, an attempt is made to skip this element. To do this, we need to skip the text element `1` and arrive at the end element `</number>`. This is done as follows :

```
$n = $xml->localName;
$ns = $xml->namespaceURI;
//skip the unknown element
while ($xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName != $n && $xml->namespaceURI != $ns) {
  $xml->read();
}
```

- `$xml->nodeType != \XMLReader::END_ELEMENT` starts out `true` (we're at `number` which is an `XMLReader::ELEMENT`)
- `$xml->localName != $n` starts out as `false`
- `$xml->namespaceURI != $ns` starts out `false`

So, we never enter the `while` loop and thus the unknown element isn't skipped.

To remedy this, I suggest the following :

- Add an `$xml->read()` to ensure that we always move one element ahead. Since we're inside a condition that ensures that we are not operating on an empty element, we are guaranteed to as a minimum jump on to the end element. Similar approach already applies for other types in `client-complex-type.fmt`.
- In my case, `$xml->namespaceURI` (and `$ns`) was empty strings, so the comparison of these one would never evaluate to `true`. I thus suggest a few extra checks for empty values, as well as the use of strict comparison operators.
