### PR TITLE
Fix for parsing "unknown" nested DOM elements with PHP XML client

### DIFF
--- a/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
+++ b/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
@@ -254,11 +254,7 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     $dom = $e;
 
                     //create any child elements...
-<<<<<<< Updated upstream
-                    while ($xml->read() && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns) {
-=======
                     while ($xml->read() && !$this->hasSameValue($d, $xml->depth, false) && !$this->hasSameValue($n, $xml->localName) && !$this->hasSameValue($ns, $xml->namespaceURI)) {
->>>>>>> Stashed changes
                         if ($xml->nodeType == \XMLReader::ELEMENT) {
                             $e = $nodeFactory->createElementNS($xml->namespaceURI, $xml->localName);
                             $dom->appendChild($e);
@@ -281,15 +277,7 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     array_push($this->${type.anyElement.clientSimpleName}, $nodeFactory);
       [#else]
                     //skip the unknown element
-<<<<<<< HEAD
-<<<<<<< Updated upstream
-                    while ($xml->read && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns);
-=======
                     while ($xml->read() && !$this->hasSameValue($d, $xml->depth, false) && !$this->hasSameValue($n, $xml->localName) && !$this->hasSameValue($ns, $xml->namespaceURI));
->>>>>>> Stashed changes
-=======
-                    while ($xml->read && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns);
->>>>>>> f5fc8cdeb940deeff93525aaa016a1e491850447
       [/#if]
                 }
                 $xml->read(); //advance the reader.

--- a/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
+++ b/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
@@ -229,8 +229,14 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     //no-op: skip any insignificant whitespace, comments, etc.
                 }
                 else if (!$xml->isEmptyElement && !$this->setKnownChildElement($xml)) {
+<<<<<<< Updated upstream
                     $n = empty($xml->localName) ? NULL : $xml->localName;
                     $ns = empty($xml->namespaceURI) ? NULL : $xml->namespaceURI;
+=======
+                    $d = $xml->depth;
+                    $n = $xml->localName;
+                    $ns = $xml->namespaceURI;
+>>>>>>> Stashed changes
       [#if type.anyElement??]
                     $dom = new \DOMDocument();
                     $nodeFactory = $dom;
@@ -248,7 +254,11 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     $dom = $e;
 
                     //create any child elements...
+<<<<<<< Updated upstream
                     while ($xml->read() && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns) {
+=======
+                    while ($xml->read() && !$this->hasSameValue($d, $xml->depth, false) && !$this->hasSameValue($n, $xml->localName) && !$this->hasSameValue($ns, $xml->namespaceURI)) {
+>>>>>>> Stashed changes
                         if ($xml->nodeType == \XMLReader::ELEMENT) {
                             $e = $nodeFactory->createElementNS($xml->namespaceURI, $xml->localName);
                             $dom->appendChild($e);
@@ -271,9 +281,11 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     array_push($this->${type.anyElement.clientSimpleName}, $nodeFactory);
       [#else]
                     //skip the unknown element
-                    while ($xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns) {
-                        $xml->read();
-                    }
+<<<<<<< Updated upstream
+                    while ($xml->read && $xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns);
+=======
+                    while ($xml->read() && !$this->hasSameValue($d, $xml->depth, false) && !$this->hasSameValue($n, $xml->localName) && !$this->hasSameValue($ns, $xml->namespaceURI));
+>>>>>>> Stashed changes
       [/#if]
                 }
                 $xml->read(); //advance the reader.
@@ -283,6 +295,25 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
     }
 
   [/#if]
+
+    /**
+     * Evaluates if two values are the same using strict comparison.
+     * 
+     * @param mixed $n1 the first value
+     * @param mixed $n2 the second value
+     * @param boolean $evaluateTwoEmptyValuesToFalse treat two empty values (as
+     * deemed empty by <code>empty()</code> as not equal. This is useful when
+     * comparing text nodes (which does not have a name) or empty namespace.
+     * @return boolean a <code>boolean</code> indicating if the two values are
+     * are the same using the strict '===' operator.
+     */
+    private function hasSameValue($n1, $n2, $evaluateTwoEmptyValuesToFalse = true) {
+      if ($evaluateTwoEmptyValuesToFalse && empty($n1) && empty($n2)) {
+        return false;
+      }
+    
+      return $n1 === $n2;
+    }
 
     /**
      * Sets a known child element of ${simpleNameFor(type)} from an XML reader.

--- a/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
+++ b/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
@@ -229,14 +229,9 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
                     //no-op: skip any insignificant whitespace, comments, etc.
                 }
                 else if (!$xml->isEmptyElement && !$this->setKnownChildElement($xml)) {
-<<<<<<< Updated upstream
-                    $n = empty($xml->localName) ? NULL : $xml->localName;
-                    $ns = empty($xml->namespaceURI) ? NULL : $xml->namespaceURI;
-=======
                     $d = $xml->depth;
                     $n = $xml->localName;
                     $ns = $xml->namespaceURI;
->>>>>>> Stashed changes
       [#if type.anyElement??]
                     $dom = new \DOMDocument();
                     $nodeFactory = $dom;


### PR DESCRIPTION
I ran into trouble parsing the below piece of XML. The issue was that `<trackGenreRelationships>` is an unknown element. So the code attempts to skip subsequent elements and 'fast forward' to `</trackGenreRelationships>`. It skips elements as long as the current element is (1) not an end element, ***and*** (2) not has the name `trackGenreRelationships` ***and*** (3) not has the same namespace as `trackGenreRelationships`. As long as these 3 conditions ***all*** evaluate to `true`, elements are skipped.

Looking at the XML below, we come across `</genre>` which is an end element. This means that this one doesn't evaluate to `true` : 

`$xml->nodeType != \XMLReader::END_ELEMENT && $xml->localName !== $n && $xml->namespaceURI !== $ns`

After this, things break.

Instead of looking for the end element, I've tried using a combination of depth, name and namespace. Elements are skipped until we're back at the same depth, and name + namespace is the same. 

Furthemore, I've added a function which evaluates two empty values as different because.  This is useful because we're not interested in DOM elements where both names are empty (text nodes) and if namespace is empty, then we basically just want to take this one out of the equation.

Parsing works well with this change.

```
<track>
	<distribute>true</distribute>
	<trackGenreRelationships>
		<trackGenreRelationship>
			<genre parent="75225b2a-d1bf-4b1d-b8e7-ef3510256052">
				<id>904799e9-6c89-42ea-aa2d-1df5cf26e32f</id>
				<name>Rock</name>
				<updated>2009-07-15T08:34:38</updated>
			</genre>
			<id>2b51b6f3-5e0b-430a-956c-d9706b84a050</id>
			<status name="Active">2</status>
			<updated>2013-01-10T14:46:16</updated>
		</trackGenreRelationship>
	</trackGenreRelationships>
</track>
```