### PR TITLE
upgrade plugin versions for jdk11

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -65,11 +65,6 @@
 
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,11 @@
     <joda-convert.version>1.8.1</joda-convert.version>
     <junit.version>4.12</junit.version>
     <lombok.version>1.16.14</lombok.version>
-    <maven-api.version>2.2.1</maven-api.version>
+    <maven-api.version>3.6.0</maven-api.version>
     <maven-filtering.version>1.3</maven-filtering.version>
     <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
     <pegdown.version>1.6.0</pegdown.version>
-    <plexus-utils.version>3.0.22</plexus-utils.version>
+    <plexus-utils.version>3.1.1</plexus-utils.version>
     <plexus-interpolation.version>1.22</plexus-interpolation.version>
     <reflections.version>0.9.9</reflections.version>
     <rxjava.version>1.1.5</rxjava.version>
@@ -109,19 +109,19 @@
     <!--plugin versions-->
     <echo-maven-plugin.version>1.2.0</echo-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
-    <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
-    <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
-    <maven-plugin-plugin.version>3.5.1</maven-plugin-plugin.version>
-    <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-    <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+    <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+    <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
+    <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
-    <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-    <maven-jar-plugin.version>2.6</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
-    <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
-    <maven-source-plugin.version>2.4</maven-source-plugin.version>
+    <maven-install-plugin.version>3.0.0-M1</maven-install-plugin.version>
+    <maven-jar-plugin.version>3.1.1</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
+    <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+    <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <animal-sniffer-maven-plugin.version>1.16</animal-sniffer-maven-plugin.version>
-    <maven-enforcer-plugin.version>1.4</maven-enforcer-plugin.version>
+    <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     <maven-inherit-plugin.version>1.5</maven-inherit-plugin.version>
     <maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>
@@ -538,12 +538,6 @@ your path down the rabbit hole.</message>
       <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
-        <version>${maven-api.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-project</artifactId>
         <version>${maven-api.version}</version>
       </dependency>
 

--- a/slim-maven-plugin/pom.xml
+++ b/slim-maven-plugin/pom.xml
@@ -87,10 +87,15 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-project</artifactId>
+      <artifactId>maven-compat</artifactId>
+      <version>3.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven.reporting</groupId>
+      <artifactId>maven-reporting-api</artifactId>
+      <version>3.0</version>
     </dependency>
 
     <dependency>

--- a/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/DeployArtifactBaseMojo.java
+++ b/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/DeployArtifactBaseMojo.java
@@ -31,7 +31,6 @@ import com.webcohesion.enunciate.artifacts.FileArtifact;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.deployer.ArtifactDeployer;
 import org.apache.maven.artifact.deployer.ArtifactDeploymentException;
-import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.metadata.ArtifactMetadata;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.DefaultArtifactRepository;
@@ -47,6 +46,7 @@ import org.apache.maven.plugins.annotations.*;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.MavenProjectHelper;
 import org.apache.maven.project.artifact.ProjectArtifactMetadata;
+import org.apache.maven.repository.RepositorySystem;
 import org.codehaus.plexus.PlexusConstants;
 import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
@@ -129,7 +129,7 @@ public class DeployArtifactBaseMojo extends AbstractMojo implements Contextualiz
    * Component used to create an artifact
    */
   @Component
-  protected ArtifactFactory artifactFactory;
+  protected RepositorySystem artifactFactory;
 
   /**
    * Location of an existing POM file to be deployed alongside the artifact(s).

--- a/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/InstallArtifactBaseMojo.java
+++ b/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/InstallArtifactBaseMojo.java
@@ -19,13 +19,13 @@ import com.webcohesion.enunciate.Enunciate;
 import com.webcohesion.enunciate.artifacts.ArtifactType;
 import com.webcohesion.enunciate.artifacts.ClientLibraryArtifact;
 import com.webcohesion.enunciate.artifacts.FileArtifact;
-import org.apache.maven.plugin.install.InstallFileMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.plugins.install.InstallFileMojo;
 import org.apache.maven.project.MavenProject;
 
 import java.io.File;
@@ -40,10 +40,19 @@ import java.lang.reflect.Field;
 @Mojo ( name = "install-artifact", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME )
 public class InstallArtifactBaseMojo extends InstallFileMojo {
 
-  /**
-   * The Maven project reference.
-   */
-  @Parameter( defaultValue = "${project}", required = true, readonly = true)
+  @Parameter( property = "groupId" )
+  private String groupId;
+
+  @Parameter( property = "artifactId" )
+  private String artifactId;
+
+  @Parameter( property = "version" )
+  private String version;
+
+  @Parameter( property = "packaging" )
+  private String packaging;
+
+  @Parameter( defaultValue = "${project}", required = true, readonly = true )
   protected MavenProject project;
 
   @Parameter


### PR DESCRIPTION
The Maven plugin versions used in Enunciate build are very old, and many of them blow up terribly in Java 11.  While this PR does not add the full ability to build in Java 11, it upgrades the Maven versions enough that it does not cause internal exceptions to be thrown.  (For example, the ancient Enforcer plugin cannot even parse the Java 11 version well enough to fail)