### PR TITLE
Immutables improvements

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
@@ -45,6 +45,7 @@ import com.webcohesion.enunciate.util.OneTimeLogMessage;
 import com.webcohesion.enunciate.util.TypeHintUtils;
 
 import javax.activation.DataHandler;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -338,12 +339,21 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
 
     return el.getAnnotation(JsonIgnore.class) != null && el.getAnnotation(JsonIgnore.class).value();
   }
-  
+
   public AccessorVisibilityChecker getDefaultVisibility() {
     return this.defaultVisibility;
   }
 
   public void add(TypeDefinition typeDef, LinkedList<Element> stack) {
+    for (AnnotationMirror a : typeDef.getAnnotationMirrors()) {
+      Element element = a.getAnnotationType().asElement();
+      if (((TypeElement) element).getQualifiedName().contentEquals("org.immutables.value.Generated"))
+      {
+        debug("excluding %s due to @Generated", typeDef.getQualifiedName());
+        return;
+      }
+    }
+
     if (findTypeDefinition(typeDef) == null && !isKnownType(typeDef)) {
       this.typeDefinitions.put(typeDef.getQualifiedName().toString(), typeDef);
 

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/JacksonModule.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/JacksonModule.java
@@ -214,8 +214,8 @@ public class JacksonModule extends BasicProviderModule implements TypeDetectingM
   }
 
   protected boolean isExplicitTypeDefinition(Element declaration, boolean honorJaxb) {
-    if (declaration.getKind() != ElementKind.CLASS && declaration.getKind() != ElementKind.ENUM) {
-      debug("%s isn't a potential Jackson type because it's not a class or an enum.", declaration);
+    if (declaration.getKind() != ElementKind.CLASS && declaration.getKind() != ElementKind.ENUM && declaration.getKind() != ElementKind.INTERFACE) {
+      debug("%s isn't a potential Jackson type because it's not a class or an enum or interface.", declaration);
       return false;
     }
 

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/PropertyImpl.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/api/impl/PropertyImpl.java
@@ -22,6 +22,7 @@ import com.webcohesion.enunciate.api.datatype.Property;
 import com.webcohesion.enunciate.facets.Facet;
 import com.webcohesion.enunciate.javac.decorations.element.ElementUtils;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
+import com.webcohesion.enunciate.javac.javadoc.JavaDoc.JavaDocTagList;
 import com.webcohesion.enunciate.metadata.ReadOnly;
 import com.webcohesion.enunciate.modules.jackson.model.Member;
 import com.webcohesion.enunciate.modules.jackson.model.types.JsonArrayType;
@@ -63,7 +64,12 @@ public class PropertyImpl implements Property {
 
   @Override
   public String getDescription() {
-    return this.member.getJavaDoc(this.registrationContext.getTagHandler()).toString();
+    JavaDoc javaDoc = this.member.getJavaDoc(this.registrationContext.getTagHandler());
+    JavaDocTagList returns = javaDoc.get("return");
+    if (returns != null && !returns.isEmpty() && javaDoc.toString().trim().isEmpty()) {
+        return returns.get(0);
+    }
+    return javaDoc.toString();
   }
 
   @Override

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/TypeDefinition.java
@@ -16,6 +16,8 @@
 package com.webcohesion.enunciate.modules.jackson.model;
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.webcohesion.enunciate.EnunciateException;
 import com.webcohesion.enunciate.facets.Facet;
 import com.webcohesion.enunciate.facets.HasFacets;
@@ -37,7 +39,11 @@ import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Types;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlType;
+
+import java.lang.annotation.Annotation;
 import java.util.*;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * A json type definition.
@@ -567,19 +573,45 @@ public abstract class TypeDefinition extends DecoratedTypeElement implements Has
       super(env);
     }
 
+    private <A extends Annotation> DecoratedExecutableElement refine(DecoratedExecutableElement executable, Class<A> annotation, Function<A, Class<?>> refiner) {
+      Element elt = executable;
+      while (elt != null && elt.getKind() != ElementKind.CLASS && elt.getKind() != ElementKind.INTERFACE) {
+        elt = elt.getEnclosingElement();
+      }
+      if (elt == null) {
+        return executable;
+      }
+      final A js = env.getElementUtils().getTypeElement(((DecoratedTypeElement)elt).getQualifiedName()).getAnnotation(annotation);
+
+      if (js != null) {
+        DeclaredType as = (DeclaredType) Annotations.mirrorOf(() -> refiner.apply(js), env, Void.class);
+        if (as == null) {
+          return executable;
+        }
+        for (Element elem : as.asElement().getEnclosedElements()) {
+          if (elem.getSimpleName().equals(executable.getSimpleName()) && elem instanceof ExecutableElement) {
+            return new DecoratedExecutableElement((ExecutableElement) elem, env); 
+          }
+        }
+      }
+      return executable;
+    }
+
     @Override
     public boolean isGetter(DecoratedExecutableElement executable) {
+      executable = refine(executable, JsonSerialize.class, JsonSerialize::as);
       return executable.isGetter() || (executable.getParameters().isEmpty() && (executable.getAnnotation(JsonProperty.class) != null || executable.getAnnotation(JsonValue.class) != null));
     }
 
     @Override
     public boolean isSetter(DecoratedExecutableElement executable) {
+      executable = refine(executable, JsonDeserialize.class, JsonDeserialize::as);
       return executable.isSetter() || (executable.getParameters().size() == 1 && (executable.getAnnotation(JsonProperty.class) != null || executable.getAnnotation(JsonValue.class) != null));
     }
 
     @Override
     public String getPropertyName(DecoratedExecutableElement method) {
-      JsonProperty jsonProperty = method.getAnnotation(JsonProperty.class);
+      JsonProperty jsonProperty = refine(method, JsonSerialize.class, JsonSerialize::as).getAnnotation(JsonProperty.class);
       if (jsonProperty != null) {
         String propertyName = jsonProperty.value();
         if (!propertyName.isEmpty()) {

--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/ElementUtils.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/ElementUtils.java
@@ -106,7 +106,7 @@ public class ElementUtils {
 
   public static class DefaultPropertySpec implements PropertySpec {
 
-    private final DecoratedProcessingEnvironment env;
+    protected final DecoratedProcessingEnvironment env;
 
     public DefaultPropertySpec(DecoratedProcessingEnvironment env) {
       this.env = env;


### PR DESCRIPTION
We use [Immutables](https://immutables.github.io/) to generate our Jackson data types.  This PR proposes some simple improvements to better respect its generated code.

* Well-behaved annotation processors will emit source code tagged as `@Generated`.  Enunciate should ignore these files, all documentation information will always be in user-written sources, and you do not need to see the generated serialization proxies.

* Jackson types may be simple interfaces, both Immutables as well as the MrBean proxy generator will allow this.

* When retrieving information on properties, respect `@JsonProperty` annotations on the method as refined by `@JsonSerialize(as=)` or `@JsonDeserialize(as=)`

* When a property has an empty description but a non-empty `@return` javadoc tag, use it.