### PR TITLE
Only show abstract type warning if there are any actual subtypes

### DIFF
--- a/docs/src/main/resources/com/webcohesion/enunciate/modules/docs/docs.fmt
+++ b/docs/src/main/resources/com/webcohesion/enunciate/modules/docs/docs.fmt
@@ -1142,7 +1142,7 @@ ${method.example.responseBody?xhtml}
       [#if type.example??]
 
       <p class="lead">Example</p>
-        [#if type.abstract]
+        [#if type.abstract && type.subtypes?? ]
 
       <div class="alert alert-warning">This data type is abstract. The example below may be incomplete. More accurate examples can be found in subtypes pages.</div>
         [/#if]


### PR DESCRIPTION
Otherwise, it just has "please see subtype pages" with no actual links, which is misleading.