### PR TITLE
Ensure PHP client parses boolean and double values correctly

### DIFF
--- a/php-xml-client/src/main/java/com/webcohesion/enunciate/modules/php_xml_client/ClientClassnameForMethod.java
+++ b/php-xml-client/src/main/java/com/webcohesion/enunciate/modules/php_xml_client/ClientClassnameForMethod.java
@@ -15,7 +15,6 @@
  */
 package com.webcohesion.enunciate.modules.php_xml_client;
 
-
 import com.webcohesion.enunciate.api.datatype.DataTypeReference;
 import com.webcohesion.enunciate.api.resources.Entity;
 import com.webcohesion.enunciate.api.resources.MediaTypeDescriptor;
@@ -66,10 +65,10 @@ public class ClientClassnameForMethod extends com.webcohesion.enunciate.util.fre
     classConversions.put(Integer.class.getName(), "Integer");
     classConversions.put(Short.class.getName(), "Integer");
     classConversions.put(Byte.class.getName(), "Integer");
-    classConversions.put(Double.class.getName(), "Integer");
+    classConversions.put(Double.class.getName(), "Double");
     classConversions.put(Long.class.getName(), "Integer");
-    classConversions.put(java.math.BigInteger.class.getName(), "Integer");
-    classConversions.put(java.math.BigDecimal.class.getName(), "Integer");
+    classConversions.put(java.math.BigInteger.class.getName(), "String");
+    classConversions.put(java.math.BigDecimal.class.getName(), "String");
     classConversions.put(Float.class.getName(), "Integer");
     classConversions.put(Character.class.getName(), "Integer");
     classConversions.put(Date.class.getName(), "String");
@@ -161,6 +160,7 @@ public class ClientClassnameForMethod extends com.webcohesion.enunciate.util.fre
         case CHAR:
         case FLOAT:
         case DOUBLE:
+          return "Double";
         case LONG:
           return "Integer";
         default:

--- a/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
+++ b/php-xml-client/src/main/resources/com/webcohesion/enunciate/modules/php_xml_client/client-complex-type.fmt
@@ -18,7 +18,7 @@
 --]
 [#--template for the client-side complex type.--]
 [#macro createPhpXmlObject targetVariable currentClass indent]
-    [#if currentClass == "String" || currentClass == "Integer" || currentClass == "Boolean" || currentClass == "Array"]
+    [#if currentClass == "String" || currentClass == "Integer" || currentClass == "Double" || currentClass == "Boolean" || currentClass == "Array"]
 ${indent}${targetVariable} = '';
 ${indent}while ($xml->read() && $xml->hasValue) {
 ${indent}    ${targetVariable} = ${targetVariable} . $xml->value;
@@ -30,11 +30,26 @@ ${indent}${targetVariable} = new \${currentClass}($xml);
     [/#if]
 [/#macro]
 [#macro toPhpXmlInstance currentIdentifier currentClass indent]
-    [#if currentClass == "String" || currentClass == "Integer" || currentClass == "Boolean" || currentClass == "Array"]
+    [#if currentClass == "String" || currentClass == "Integer" || currentClass == "Double" || currentClass == "Boolean" || currentClass == "Array"]
 ${indent}$writer->text(${currentIdentifier});
     [#else]
 ${indent}${currentIdentifier}->writeXmlContents($writer);
     [/#if]
+[/#macro]
+[#macro toPhpXmlType currentIdentifier currentClass indent]
+[#switch currentClass]
+    [#case "Boolean"]
+${indent}${currentIdentifier} = filter_var($child, FILTER_VALIDATE_BOOLEAN);
+    [#break]
+    [#case "Double"]
+${indent}${currentIdentifier} = floatval($child);
+    [#break]   
+    [#case "Integer"]
+${indent}${currentIdentifier} = intval($child);
+    [#break]        
+    [#default]
+${indent}${currentIdentifier} = $child;
+[/#switch]
 [/#macro]
 [#macro writeComplexType type]
 [#-- @ftlvariable name="type" type="com.webcohesion.enunciate.modules.jaxb.model.TypeDefinition" --]
@@ -344,15 +359,15 @@ class ${simpleNameFor(type)}[#if !type.baseObject] extends \${classnameFor(type.
             }
             array_push($this->${element.clientSimpleName}, $child);
             [#else]
-            $this->${element.clientSimpleName} = $child;
+[@toPhpXmlType '$this->${element.clientSimpleName}' '${classnameFor(element)}' '            '/]
             [/#if]
             $happened = true;
         }
             [#assign writeElse=true/]
           [/#list]
           [#if element.wrapped]
-                $xml->read();
-            }
+        $xml->read();
+        }
             $happened = true;
         }
           [/#if]


### PR DESCRIPTION
Right now the PHP client parses booleans as strings and double/floats as integers. This PR refactors that part to ensure that booleans are parsed as actual boolean types, and doubles/floats are parsed as floats. 