### PR TITLE
Add support for nested arrays

### DIFF
--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.webcohesion.enunciate.javac.decorations.Annotations;
 import com.webcohesion.enunciate.javac.decorations.DecoratedProcessingEnvironment;
 import com.webcohesion.enunciate.javac.decorations.TypeMirrorDecorator;
+import com.webcohesion.enunciate.javac.decorations.type.DecoratedArrayType;
 import com.webcohesion.enunciate.javac.decorations.type.DecoratedTypeMirror;
 import com.webcohesion.enunciate.metadata.rs.TypeHint;
 import com.webcohesion.enunciate.modules.jackson.EnunciateJacksonContext;
@@ -173,8 +174,20 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
   }
 
   @Override
-  public JsonType visitArray(ArrayType arrayType, Context context) {
-    return arrayType.getComponentType().accept(this, new Context(context.context, true, false, context.stack));
+    public JsonType visitArray(ArrayType arrayType, Context context) {
+
+        final TypeMirror componentType = arrayType.getComponentType();
+        if (hasComponentTypeArray(componentType)) {
+            return new JsonArrayType(visitArray((DecoratedArrayType) componentType, context));
+        } 
+	else {
+            return componentType.accept(this, new Context(context.context, true, false, context.stack));
+        }
+    }
+
+    // i.e. a nested array
+    private boolean hasComponentTypeArray(TypeMirror componentType) {
+        return componentType.getKind().compareTo(TypeKind.ARRAY) == 0;
   }
 
   @Override

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
@@ -176,13 +176,13 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
   @Override
     public JsonType visitArray(ArrayType arrayType, Context context) {
 
-        final TypeMirror componentType = arrayType.getComponentType();
-        if (hasComponentTypeArray(componentType)) {
-            return new JsonArrayType(visitArray((ArrayType) componentType, context));
-        } 
-	else {
-            return componentType.accept(this, new Context(context.context, true, false, context.stack));
-        }
+      final TypeMirror componentType = arrayType.getComponentType();
+      if (hasComponentTypeArray(componentType)) {
+        return new JsonArrayType(visitArray((ArrayType) componentType, context));
+      }
+	  else {
+        return componentType.accept(this, new Context(context.context, true, false, context.stack));
+      }
     }
 
     // i.e. a nested array

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/types/JsonTypeVisitor.java
@@ -178,7 +178,7 @@ public class JsonTypeVisitor extends SimpleTypeVisitor6<JsonType, JsonTypeVisito
 
         final TypeMirror componentType = arrayType.getComponentType();
         if (hasComponentTypeArray(componentType)) {
-            return new JsonArrayType(visitArray((DecoratedArrayType) componentType, context));
+            return new JsonArrayType(visitArray((ArrayType) componentType, context));
         } 
 	else {
             return componentType.accept(this, new Context(context.context, true, false, context.stack));


### PR DESCRIPTION
If a domain class has a field of type multi dimensional array, e.g.
double[][], then in the documentation the type was incorrect (in
this example it ends up as double[] in the HTML).

This commit makes sure that in this case the HTML contains the correct
type, double[][]. This only works when the getter of the field contains
the @typehint annotation, e.g. @typehint(double[][].class.