### PR TITLE
Add Bean Validation Group support for Jackson

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,6 +92,11 @@
       <optional>true</optional>
     </dependency>
 
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/core/src/main/java/com/webcohesion/enunciate/beanval/ValidationGroupHelper.java
+++ b/core/src/main/java/com/webcohesion/enunciate/beanval/ValidationGroupHelper.java
@@ -1,0 +1,85 @@
+package com.webcohesion.enunciate.beanval;
+
+import javax.lang.model.element.AnnotationMirror;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+public class ValidationGroupHelper {
+
+    static List<String> getGroupsOnField(String groupsAsString) {
+        List<String> classes = new ArrayList<>();
+
+        final String validationGroupsPrefix = "groups()={";
+        int indexOfGroups = groupsAsString.indexOf(validationGroupsPrefix);
+
+        if (indexOfGroups == -1) {
+            return Collections.emptyList();
+        }
+
+        String tail = groupsAsString.substring(indexOfGroups);
+        int indexOfClosingBrace = tail.indexOf("}");
+
+
+        classes = addClasses(classes, tail.substring(validationGroupsPrefix.length(), indexOfClosingBrace));
+
+        return classes;
+    }
+
+    private static List<String> addClasses(List<String> classes, String validationGroups) {
+
+        return Stream.of(validationGroups.split(",")).map(ValidationGroupHelper::stripDotClass).collect(toList());
+    }
+
+    private static String stripDotClass(String className) {
+
+        return className.replace(".class", "").trim();
+
+    }
+
+    private static List<String> getActiveValidationGroups(String activeValidationGroups) {
+        if (activeValidationGroups != null && activeValidationGroups.length() > 0) {
+
+            return Stream.of(activeValidationGroups.split(",")).map(String::trim).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
+    }
+
+    public static boolean hasMatchingValidationGroup(String targetGroups, AnnotationMirror annotationMirror) {
+        // get validationGroups from Enunciate config file, this holds the active validation groups (if any) in attribute
+        // "beanValidationGroups" of jackson module:
+        // e.g. <jackson disabled="false" beanValidationGroups="com.ifyouwannabecool.beanval.DataAPI"/>
+        List<String> activeValidationGroups = ValidationGroupHelper.getActiveValidationGroups(targetGroups);
+        if (annotationMirror != null) {
+            List<String> groupsOnField = getGroupsOnField(annotationMirror.getElementValues().toString());
+
+            if (runningWithDefaultGroupOnFieldInDefaultGroup(groupsOnField, activeValidationGroups)) {
+                return true;
+            }
+            if (validationGroupOnFieldMatchesWithActiveGroup(groupsOnField, activeValidationGroups)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * When Enunciate XML does not have validationGroups specified then the constraint is only active when the field has
+     * no groups specified either.
+     */
+    private static boolean runningWithDefaultGroupOnFieldInDefaultGroup(List<String> groupsOnField, List<String> activeValidationGroups) {
+        return groupsOnField.isEmpty() && activeValidationGroups.isEmpty();
+    }
+
+    /**
+     * if at least one validation group matches, then the constraint should be applied
+     */
+    private static boolean validationGroupOnFieldMatchesWithActiveGroup(List<String> groupsOnField, List<String> activeValidationGroups) {
+        return groupsOnField.stream().anyMatch(activeValidationGroups::contains);
+    }
+
+}

--- a/core/src/test/java/com/webcohesion/enunciate/beanval/ValidationGroupHelperTest.java
+++ b/core/src/test/java/com/webcohesion/enunciate/beanval/ValidationGroupHelperTest.java
@@ -1,0 +1,97 @@
+package com.webcohesion.enunciate.beanval;
+
+import com.webcohesion.enunciate.beanval.ValidationGroupHelper;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.Mockito;
+
+import javax.lang.model.element.AnnotationMirror;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ValidationGroupHelperTest {
+
+        @Test
+        public void getSingleGroupOnField() {
+
+            String input = "{groups()={com.a.A.class}}";
+            assertEquals(Arrays.asList("com.a.A"), ValidationGroupHelper.getGroupsOnField(input));
+        }
+
+        @Test
+        public void getMultipleGroupsOnField() {
+
+            String input = "{groups()={com.a.A.class, com.b.B.class}}";
+            assertEquals(Arrays.asList("com.a.A", "com.b.B"), ValidationGroupHelper.getGroupsOnField(input));
+        }
+
+        @Test
+        public void getMultipleGroupsOnFieldWithOtherAttributes() {
+
+            String input = "{names()={a,b},groups()={com.a.A.class, com.b.B.class},age()={12}}";
+            assertEquals(Arrays.asList("com.a.A", "com.b.B"), ValidationGroupHelper.getGroupsOnField(input));
+        }
+
+        @Test
+        public void getNoGroupsOnFieldWithOtherAttributes() {
+
+            String input = "{names()={a,b},age()={12}}";
+            assertEquals(Collections.emptyList(), ValidationGroupHelper.getGroupsOnField(input));
+        }
+
+        Map<String, AnnotationMirror> fieldAnnotations = new HashMap<>();
+
+        @Test
+        public void verifyNotRequiredWhenNotNullAnnotationIsMissing() {
+            assertFalse("Field does not have @NotNull", ValidationGroupHelper.hasMatchingValidationGroup("com.a.A, com.b.B", null));
+        }
+
+        @Test
+        public void verifyNotRequiredWhenConfigHasDefaultGroupAndFieldHasGroups() {
+
+            AnnotationMirror mockedMirror = Mockito.mock(AnnotationMirror.class, Answers.RETURNS_DEEP_STUBS);
+            Mockito.when(mockedMirror.getElementValues().toString()).thenReturn("{names()={a,b},groups()={com.a.A.class, com.b.B.class},age()={12}}");
+
+            assertFalse("Field does not have @NotNull with groups, but validation runs with default group", ValidationGroupHelper.hasMatchingValidationGroup("", mockedMirror));
+        }
+
+        @Test
+        public void verifyNotRequiredWhenConfigHasDefaultGroupAndFieldHasNoGroups() {
+
+            AnnotationMirror mockedMirror = Mockito.mock(AnnotationMirror.class, Answers.RETURNS_DEEP_STUBS);
+            Mockito.when(mockedMirror.getElementValues().toString()).thenReturn("{names()={a,b},age()={12}}");
+
+            assertTrue("Field does have @NotNull without groups and validation runs with default group", ValidationGroupHelper.hasMatchingValidationGroup("", mockedMirror));
+        }
+
+        @Test
+        public void verifyNotRequiredWhenConfigHasGroupAndFieldHasNoGroups() {
+
+            AnnotationMirror mockedMirror = Mockito.mock(AnnotationMirror.class, Answers.RETURNS_DEEP_STUBS);
+            Mockito.when(mockedMirror.getElementValues().toString()).thenReturn("{names()={a,b},age()={12}}");
+
+            assertFalse("Field does have @NotNull without groups, but validation runs with specific groups", ValidationGroupHelper.hasMatchingValidationGroup("com.c.C, com.b.B", mockedMirror));
+        }
+
+        @Test
+        public void verifyNotRequiredWhenConfigHasGroupAndFieldHasMatchingGroups() {
+
+            AnnotationMirror mockedMirror = Mockito.mock(AnnotationMirror.class, Answers.RETURNS_DEEP_STUBS);
+            Mockito.when(mockedMirror.getElementValues().toString()).thenReturn("{names()={a,b},groups()={com.a.A.class, com.b.B.class},age()={12}}");
+
+            assertTrue("Field does have @NotNull with groups, and validation runs with specific group", ValidationGroupHelper.hasMatchingValidationGroup("com.c.C, com.b.B", mockedMirror));
+        }
+
+        @Test
+        public void verifyNotRequiredWhenConfigHasGroupAndFieldHasNoMatchingGroups() {
+
+            AnnotationMirror mockedMirror = Mockito.mock(AnnotationMirror.class, Answers.RETURNS_DEEP_STUBS);
+            Mockito.when(mockedMirror.getElementValues().toString()).thenReturn("{names()={a,b},groups()={com.a.A.class, com.d.D.class},age()={12}}");
+
+            assertFalse("Field does have @NotNull with groups, and validation runs with specific group, but none is matching", ValidationGroupHelper.hasMatchingValidationGroup("com.c.C, com.b.B", mockedMirror));
+        }
+}

--- a/jackson/pom.xml
+++ b/jackson/pom.xml
@@ -21,6 +21,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/EnunciateJacksonContext.java
@@ -82,8 +82,9 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
   private final AccessorVisibilityChecker defaultVisibility;
   private final String propertyNamingStrategy;
   private final boolean propertiesAlphabetical;
+  private final String beanValidationGroups;
 
-  public EnunciateJacksonContext(EnunciateContext context, boolean honorJaxb, boolean honorGson, KnownJsonType dateType, boolean collapseTypeHierarchy, Map<String, String> mixins, Map<String, String> examples, AccessorVisibilityChecker visibility, boolean disableExamples, boolean wrapRootValue, String propertyNamingStrategy, boolean propertiesAlphabetical) {
+  public EnunciateJacksonContext(EnunciateContext context, boolean honorJaxb, boolean honorGson, KnownJsonType dateType, boolean collapseTypeHierarchy, Map<String, String> mixins, Map<String, String> examples, AccessorVisibilityChecker visibility, boolean disableExamples, boolean wrapRootValue, String propertyNamingStrategy, boolean propertiesAlphabetical, String beanValidationGroups) {
     super(context);
     this.dateType = dateType;
     this.mixins = mixins;
@@ -99,6 +100,7 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
     this.collapseTypeHierarchy = collapseTypeHierarchy;
     this.typeDefinitionsBySlug = new HashMap<String, TypeDefinition>();
     this.wrapRootValue = wrapRootValue;
+    this.beanValidationGroups = beanValidationGroups;
   }
 
   public EnunciateContext getContext() {
@@ -135,6 +137,9 @@ public class EnunciateJacksonContext extends EnunciateModuleContext {
 
   public boolean isPropertiesAlphabetical() {
     return propertiesAlphabetical;
+  }
+  public String getBeanValidationGroups() {
+    return beanValidationGroups;
   }
 
   public DecoratedTypeMirror resolveSyntheticType(DecoratedTypeMirror type) {

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/JacksonModule.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/JacksonModule.java
@@ -69,6 +69,9 @@ public class JacksonModule extends BasicProviderModule implements TypeDetectingM
     return this.config.getBoolean("[@collapse-type-hierarchy]", false);
   }
 
+  public String getBeanValidationGroups() {
+    return this.config.getString("[@beanValidationGroups]", "");
+  }
   public boolean isWrapRootValue() {
     return this.config.getBoolean("[@wrapRootValue]", false);
   }
@@ -128,7 +131,7 @@ public class JacksonModule extends BasicProviderModule implements TypeDetectingM
       }
     }
 
-    this.jacksonContext = new EnunciateJacksonContext(context, isHonorJaxbAnnotations(), isHonorGsonAnnotations() ,getDateFormat(), isCollapseTypeHierarchy(), getMixins(), getExternalExamples(), getDefaultVisibility(), isDisableExamples(), isWrapRootValue(), getPropertyNamingStrategy(), isPropertiesAlphabetical());
+    this.jacksonContext = new EnunciateJacksonContext(context, isHonorJaxbAnnotations(), isHonorGsonAnnotations() ,getDateFormat(), isCollapseTypeHierarchy(), getMixins(), getExternalExamples(), getDefaultVisibility(), isDisableExamples(), isWrapRootValue(), getPropertyNamingStrategy(), isPropertiesAlphabetical(), getBeanValidationGroups());
     DataTypeDetectionStrategy detectionStrategy = getDataTypeDetectionStrategy();
     switch (detectionStrategy) {
       case aggressive:

--- a/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/Member.java
+++ b/jackson/src/main/java/com/webcohesion/enunciate/modules/jackson/model/Member.java
@@ -35,6 +35,9 @@ import java.lang.annotation.IncompleteAnnotationException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.concurrent.Callable;
+import com.webcohesion.enunciate.beanval.ValidationGroupHelper;
+import javax.lang.model.element.AnnotationMirror;
+import java.lang.annotation.Annotation;
 
 /**
  * An accessor that is marshalled in json to an json element.
@@ -360,5 +363,24 @@ public class Member extends Accessor {
    */
   public String getSubtypeIdProperty() {
     return subtypeIdProperty;
+  }
+
+  @Override
+  public <A extends Annotation> A getAnnotation(Class<A> annotationType) {
+
+    String annotationName = annotationType.getCanonicalName();
+    if ( !annotationName.startsWith("javax.validation.constraints")) {
+      return super.getAnnotation(annotationType);
+    }
+
+    AnnotationMirror annotationMirror = getAnnotations().get(annotationName);
+
+    if (ValidationGroupHelper.hasMatchingValidationGroup(getContext().getBeanValidationGroups(), annotationMirror)) {
+
+      return super.getAnnotation(annotationType);
+    }
+
+    //  do not apply constraint:
+    return null;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -667,6 +667,12 @@ your path down the rabbit hole.</message>
         <artifactId>pegdown</artifactId>
         <version>${pegdown.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>3.1.0</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
 
   </dependencyManagement>


### PR DESCRIPTION
Specify validation groups in Enunciate XML file, like so:
  `<jackson disabled="false" beanValidationGroups="com.ifyouwannabecool.beanval.DataAPI"/>`

Then, only constraints with this bean validation group will be applied, e.g.
@NotNull(groups = DataAPI.class)
  public String getEmail() {
    return email;
  }

For now, JAXB module does not support this.