### PR TITLE
XmlElementWrapper required attribute handled in schema generation

### DIFF
--- a/idl/src/main/resources/com/webcohesion/enunciate/modules/idl/schemalib.fmt
+++ b/idl/src/main/resources/com/webcohesion/enunciate/modules/idl/schemalib.fmt
@@ -145,7 +145,7 @@
         [#list typeDef.elements as element]
           [#if !accessorOverridesAnother(element) && !isFacetExcluded(element)]
             [#if element.wrapped]
-        <${xs}:element name="${element.wrapperName}" minOccurs="0">
+        <${xs}:element name="${element.wrapperName}" [#if element.wrapperRequired]minOccurs="1"[#else]minOccurs="0"[/#if]>
               [#if element.docValue??]
           <${xs}:annotation>
             <${xs}:documentation>

--- a/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/model/Element.java
+++ b/jaxb/src/main/java/com/webcohesion/enunciate/modules/jaxb/model/Element.java
@@ -381,6 +381,22 @@ public class Element extends Accessor {
   }
 
   /**
+   * Whether the wrapper is required.
+   *
+   * @return Whether the wrapper is required.
+   */
+  public boolean isWrapperRequired() {
+    boolean required = false;
+
+    XmlElementWrapper xmlElementWrapper = getAnnotation(XmlElementWrapper.class);
+    if (xmlElementWrapper != null) {
+        required = xmlElementWrapper.required();
+    }
+
+    return required;
+  }
+  
+  /**
    * Whether this is a choice of multiple element refs.
    *
    * @return Whether this is a choice of multiple element refs.


### PR DESCRIPTION
`@XmlElementWrapper(name = "items", required = true)`
`@XmlElementRef(name = "item")`
`private List<Item> items;`
 This currently generates schema definition:


`       <xs:sequence>`
`        <xs:element name="items" minOccurs="0">`
`          <xs:complexType>`
`            <xs:sequence>`
`              <xs:choice minOccurs="0" maxOccurs="unbounded">`
`                <xs:element ref="item"/>`
`              </xs:choice>`
`            </xs:sequence>`
`          </xs:complexType>`
`        </xs:element>`
`      </xs:sequence>`
`

This pull request handles required:
`<xs:element name="items" minOccurs="1">`