### PR TITLE
Allow @Label annotation on enum constants

### DIFF
--- a/core-annotations/src/main/java/com/webcohesion/enunciate/metadata/Label.java
+++ b/core-annotations/src/main/java/com/webcohesion/enunciate/metadata/Label.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  * @author Ryan Heaton
  */
 @Target (
-  { ElementType.TYPE }
+  { ElementType.TYPE, ElementType.FIELD }
 )
 @Retention (
   RetentionPolicy.RUNTIME


### PR DESCRIPTION
Commit 0e754bb adds support for using @label on enum values (#1014). In order to use it though, the @label annotation needs allowed to be used enum constants.