### PR TITLE
Decorate enum constant elements

### DIFF
--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/DecoratedTypeElement.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/DecoratedTypeElement.java
@@ -196,7 +196,7 @@ public class DecoratedTypeElement extends DecoratedElement<TypeElement> implemen
       List<VariableElement> fields = ElementFilter.fieldsIn(this.delegate.getEnclosedElements());
       for (VariableElement field : fields) {
         if (field.getKind() == ElementKind.ENUM_CONSTANT) {
-          constants.add(field);
+          constants.add(ElementDecorator.decorate((field), this.env));
         }
       }
     }


### PR DESCRIPTION
Commit 0e754bb adds support for using @label on enum values (#1014). However, the Javadoc of the enum constants is not searched for label tags because they are not wrapped in `DecoratedElement`.

This pull requests wraps the `VariableElement`s of enum constants in `DecoratedVariableElement`s.

Please note: This also makes enunciate scanning the enclosing enum type's Javadoc for enunciate tags. If this contains a `@label` tag will be applied to the enum type _and_ the enum constant.

Probably, this scanning of enclosing element's Javadoc should only happen conditionally. I do not know, though, in which cases `AnnotationUtils.getJavaDocTags()` actually should search enclosing element's.