### PR TITLE
Added JDK9 - JDK19 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ For more information, see the project site at http://enunciate.webcohesion.com.
 
 ## Building Enunciate ###
 
-You need Java JDK 8 to build Enunciate. Currently, it doesn't build with Java JDK 9+. Make sure Maven is
-using Java JDK 8 by setting JAVA_HOME before running Maven:
+You need at least Java JDK 8 to build. Make sure JAVA_HOME is set to >=JDK 8 before running Maven:
 
     export JAVA_HOME=/PATH/TO/JDK/8
     mvn clean install

--- a/core-annotations/pom.xml
+++ b/core-annotations/pom.xml
@@ -25,7 +25,7 @@
       <plugin>
         <groupId>org.apache.felix</groupId>
         <artifactId>maven-bundle-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>5.1.4</version>
         <extensions>true</extensions>
         <configuration>
           <instructions>

--- a/examples/contract-first/pom.xml
+++ b/examples/contract-first/pom.xml
@@ -35,7 +35,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxws-maven-plugin</artifactId>
-        <version>2.6</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -99,7 +98,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>com.sun.xml.ws</groupId>
@@ -220,11 +219,9 @@
       </properties>
       <build>
         <plugins>
-                
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>jaxws-maven-plugin</artifactId>
-            <version>2.6</version>
             <executions>
               <execution>
                 <phase>generate-sources</phase>
@@ -272,14 +269,6 @@
           </plugin>
         </plugins>
       </build>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun.xml.ws</groupId>
-          <artifactId>jaxws-rt</artifactId>
-          <version>3.0.2</version>
-        </dependency>
-      </dependencies>
     </profile>
-        
   </profiles>
 </project>

--- a/examples/contract-first/pom.xml
+++ b/examples/contract-first/pom.xml
@@ -33,9 +33,9 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.jvnet.jax-ws-commons</groupId>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxws-maven-plugin</artifactId>
-        <version>2.3</version>
+        <version>2.6</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -99,7 +99,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <dependencies>
     <dependency>
       <groupId>com.sun.xml.ws</groupId>
@@ -149,15 +149,15 @@
                     <requireProperty>
                       <property>gcc.executable</property>
                       <message>In order to build the ${project.artifactId} module, you must have gcc installed along with libxml and gnustep.
-You will need to provide the Enunciate build with a handle to those things as follows:
+                        You will need to provide the Enunciate build with a handle to those things as follows:
 
-* The 'gcc.executable' build property must provide the path to your 'gcc' executable.
-* The 'libxml.config.executable' build property must provide your libxml compiler flags
-  and library includes.
-* The 'gnustep.config.executable' build property must provide your gnustep compiler flags
-  and library includes.
+                        * The 'gcc.executable' build property must provide the path to your 'gcc' executable.
+                        * The 'libxml.config.executable' build property must provide your libxml compiler flags
+                        and library includes.
+                        * The 'gnustep.config.executable' build property must provide your gnustep compiler flags
+                        and library includes.
 
-Recommended configuration in settings.xml:
+                        Recommended configuration in settings.xml:
 
 &lt;settings&gt;
   &lt;profiles&gt;
@@ -210,5 +210,76 @@ Recommended configuration in settings.xml:
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+      </properties>
+      <build>
+        <plugins>
+                
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>jaxws-maven-plugin</artifactId>
+            <version>2.6</version>
+            <executions>
+              <execution>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>wsimport</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <wsdlDirectory>src/main/contract</wsdlDirectory>
+              <!--turn off wsimport compilation-->
+              <sourceDestDir>${project.build.directory}/generated-sources/api</sourceDestDir>
+              <!-- Needed with JAXP 1.5 -->
+              <vmArgs>
+                <vmArg>-Djavax.xml.accessExternalSchema=all</vmArg>
+              </vmArgs>
+            </configuration>
+            <dependencies>
+              <dependency>
+                <groupId>javax.annotation</groupId>
+                <artifactId>javax.annotation-api</artifactId>
+                <version>1.3.2</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>2.3.1</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.xml.ws</groupId>
+                <artifactId>jaxws-api</artifactId>
+                <version>2.3.1</version>
+              </dependency>
+              <dependency>
+                <groupId>javax.jws</groupId>
+                <artifactId>javax.jws-api</artifactId>
+                <version>1.1</version>
+              </dependency>
+              <dependency>
+                <groupId>com.sun.xml.ws</groupId>
+                <artifactId>jaxws-tools</artifactId>
+                <version>2.3.5</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+        </plugins>
+      </build>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun.xml.ws</groupId>
+          <artifactId>jaxws-rt</artifactId>
+          <version>3.0.2</version>
+        </dependency>
+      </dependencies>
+    </profile>
+        
   </profiles>
 </project>

--- a/examples/cxf/pom.xml
+++ b/examples/cxf/pom.xml
@@ -12,6 +12,10 @@
   <name>Enunciate - CXF Full API Example</name>
   <description>Enunciate Example: Full API with JAX-WS and JAX-RS on CXF.</description>
   <packaging>war</packaging>
+    
+  <properties>
+    <antrun-phase>validate</antrun-phase>
+  </properties>
 
   <build>
     <plugins>
@@ -55,7 +59,7 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <executions>
           <execution>
             <id>start-container</id>
@@ -77,7 +81,7 @@
           <container>
             <containerId>tomcat7x</containerId>
             <zipUrlInstaller>
-              <url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.79/bin/apache-tomcat-7.0.79.zip</url>
+              <url>http://archive.apache.org/dist/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.zip</url>
               <extractDir>${basedir}/cargo-installs</extractDir>
             </zipUrlInstaller>
             <append>false</append>
@@ -106,7 +110,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <dependencies>
     <dependency>
       <groupId>com.webcohesion.enunciate</groupId>
@@ -184,5 +188,45 @@
     </dependency>
 
   </dependencies>
-
+    
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven3-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>surefire-it</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/examples/cxf/src/main/resources/applicationContext.xml
+++ b/examples/cxf/src/main/resources/applicationContext.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans
+    http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+   
+</beans>

--- a/examples/full-api-edge-cases/pom.xml
+++ b/examples/full-api-edge-cases/pom.xml
@@ -187,14 +187,14 @@
                     <requireProperty>
                       <property>gmcs.executable</property>
                       <message>
-In order to build the ${project.artifactId} module, you must have Mono installed. First install Mono
-for your platform. (See http://www.mono-project.com/docs/getting-started/ and note
-there's a Windows version of Mono, too.) Then you will need to provide the Enunciate
-build with a handle to it as follows:
+                        In order to build the ${project.artifactId} module, you must have Mono installed. First install Mono
+                        for your platform. (See http://www.mono-project.com/docs/getting-started/ and note
+                        there's a Windows version of Mono, too.) Then you will need to provide the Enunciate
+                        build with a handle to it as follows:
 
-* The 'gmcs.executable' build property must provide the path to your 'gmcs' executable.
+                        * The 'gmcs.executable' build property must provide the path to your 'gmcs' executable.
 
-Recommended configuration in settings.xml:
+                        Recommended configuration in settings.xml:
 
 &lt;settings&gt;
   &lt;profiles&gt;
@@ -224,15 +224,15 @@ Recommended configuration in settings.xml:
                     <requireProperty>
                       <property>gcc.executable</property>
                       <message>In order to build the ${project.artifactId} module, you must have gcc installed along with libxml and gnustep.
-You will need to provide the Enunciate build with a handle to those things as follows:
+                        You will need to provide the Enunciate build with a handle to those things as follows:
 
-* The 'gcc.executable' build property must provide the path to your 'gcc' executable.
-* The 'libxml.config.executable' build property must provide your libxml compiler flags
-  and library includes.
-* The 'gnustep.config.executable' build property must provide your gnustep compiler flags
-  and library includes.
+                        * The 'gcc.executable' build property must provide the path to your 'gcc' executable.
+                        * The 'libxml.config.executable' build property must provide your libxml compiler flags
+                        and library includes.
+                        * The 'gnustep.config.executable' build property must provide your gnustep compiler flags
+                        and library includes.
 
-Recommended configuration in settings.xml:
+                        Recommended configuration in settings.xml:
 
 &lt;settings&gt;
   &lt;profiles&gt;
@@ -393,7 +393,7 @@ Recommended configuration in settings.xml:
           </plugin>
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven2-plugin</artifactId>
+            <artifactId>cargo-maven3-plugin</artifactId>
             <executions>
               <execution>
                 <id>start-container</id>

--- a/examples/jackson2-api-lombok/pom.xml
+++ b/examples/jackson2-api-lombok/pom.xml
@@ -12,6 +12,10 @@
   <name>Enunciate - Jackson 2 API Lombok Example</name>
   <description>Enunciate Example: Jackson 2 API Lombok</description>
   <packaging>war</packaging>
+  
+  <properties>
+    <antrun-phase>validate</antrun-phase>
+  </properties>
 
   <build>
     <plugins>
@@ -44,7 +48,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <reporting>
     <plugins>
       <plugin>

--- a/examples/jackson2-api-lombok/pom.xml
+++ b/examples/jackson2-api-lombok/pom.xml
@@ -12,7 +12,7 @@
   <name>Enunciate - Jackson 2 API Lombok Example</name>
   <description>Enunciate Example: Jackson 2 API Lombok</description>
   <packaging>war</packaging>
-  
+
   <properties>
     <antrun-phase>validate</antrun-phase>
   </properties>
@@ -48,7 +48,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <reporting>
     <plugins>
       <plugin>

--- a/examples/jackson2-api/pom.xml
+++ b/examples/jackson2-api/pom.xml
@@ -42,7 +42,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <reporting>
     <plugins>
       <plugin>
@@ -85,7 +85,7 @@
     </dependency>
 
   </dependencies>
-    
+
   <profiles>
     <profile>
       <id>[JDK 1.9]</id>

--- a/examples/jackson2-api/pom.xml
+++ b/examples/jackson2-api/pom.xml
@@ -42,7 +42,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <reporting>
     <plugins>
       <plugin>
@@ -85,5 +85,31 @@
     </dependency>
 
   </dependencies>
+    
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enunciate</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/examples/jboss/pom.xml
+++ b/examples/jboss/pom.xml
@@ -113,7 +113,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>com.webcohesion.enunciate</groupId>
@@ -126,7 +126,7 @@
       <artifactId>enunciate-rt-util</artifactId>
       <version>${enunciate.version}</version>
     </dependency>
-        
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
@@ -188,7 +188,7 @@
       <artifactId>commons-fileupload</artifactId>
       <version>${commons-fileupload.version}</version>
     </dependency>
-        
+
     <dependency>
       <groupId>org.httpunit</groupId>
       <artifactId>httpunit</artifactId>
@@ -196,9 +196,9 @@
 
       <scope>test</scope>
     </dependency>
-        
+
   </dependencies>
-    
+
   <profiles>
     <profile>
       <id>[JDK 9, ]</id>
@@ -219,7 +219,6 @@
           <artifactId>rt</artifactId>
         </dependency>
       </dependencies>
-            
     </profile>
     <profile>
       <id>[JDK 1.9]</id>

--- a/examples/jboss/pom.xml
+++ b/examples/jboss/pom.xml
@@ -15,6 +15,7 @@
 
   <properties>
     <resteasy.version>3.0.12.Final</resteasy.version>
+    <cargo-jvm-args></cargo-jvm-args>
   </properties>
 
   <build>
@@ -59,7 +60,7 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <executions>
           <execution>
             <id>start-container</id>
@@ -81,7 +82,7 @@
           <container>
             <containerId>wildfly10x</containerId>
             <zipUrlInstaller>
-              <url>http://download.jboss.org/wildfly/10.1.0.Final/wildfly-10.1.0.Final.zip</url>
+              <url>https://download.jboss.org/wildfly/18.0.1.Final/wildfly-18.0.1.Final.zip</url>
               <extractDir>${basedir}/cargo-installs</extractDir>
             </zipUrlInstaller>
             <append>false</append>
@@ -96,6 +97,7 @@
           </deployables>
           <configuration>
             <properties>
+              <cargo.jvmargs>${cargo-jvm-args}</cargo.jvmargs>
               <!--<cargo.jvmargs>-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005</cargo.jvmargs>-->
             </properties>
             <home>${project.build.directory}/jboss-config</home>
@@ -111,7 +113,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <dependencies>
     <dependency>
       <groupId>com.webcohesion.enunciate</groupId>
@@ -123,6 +125,13 @@
       <groupId>com.webcohesion.enunciate</groupId>
       <artifactId>enunciate-rt-util</artifactId>
       <version>${enunciate.version}</version>
+    </dependency>
+        
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>2.5.6</version>
+      <scope>compile</scope>
     </dependency>
 
     <dependency>
@@ -179,7 +188,7 @@
       <artifactId>commons-fileupload</artifactId>
       <version>${commons-fileupload.version}</version>
     </dependency>
-
+        
     <dependency>
       <groupId>org.httpunit</groupId>
       <artifactId>httpunit</artifactId>
@@ -187,7 +196,69 @@
 
       <scope>test</scope>
     </dependency>
-
+        
   </dependencies>
+    
+  <profiles>
+    <profile>
+      <id>[JDK 9, ]</id>
+      <activation>
+        <jdk>[9, ]</jdk>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+        <cargo-jvm-args>--add-opens java.base/java.lang=ALL-UNNAMED</cargo-jvm-args>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.ws</groupId>
+          <artifactId>rt</artifactId>
+        </dependency>
+      </dependencies>
+            
+    </profile>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven3-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>surefire-it</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/examples/jersey-storage-spring/pom.xml
+++ b/examples/jersey-storage-spring/pom.xml
@@ -49,7 +49,7 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <executions>
           <execution>
             <id>start-container</id>
@@ -71,7 +71,7 @@
           <container>
             <containerId>tomcat7x</containerId>
             <zipUrlInstaller>
-              <url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.79/bin/apache-tomcat-7.0.79.zip</url>
+              <url>http://archive.apache.org/dist/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.zip</url>
               <extractDir>${basedir}/cargo-installs</extractDir>
             </zipUrlInstaller>
             <append>false</append>
@@ -100,7 +100,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <dependencies>
     <dependency>
       <groupId>com.webcohesion.enunciate</groupId>
@@ -145,13 +145,7 @@
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.glassfish.jersey.ext</groupId>
-      <artifactId>jersey-spring3</artifactId>
-      <version>${jersey2.version}</version>
-    </dependency>
-
+        
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -177,5 +171,75 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+    
+  <profiles>
+    <profile>
+      <id>JDK[, 8]</id>
+      <activation>
+        <jdk>[, 8]</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.jersey.ext</groupId>
+          <artifactId>jersey-spring3</artifactId>
+          <version>${jersey2.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>JDK[9, ]</id>
+      <activation>
+        <jdk>[9, ]</jdk>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>org.glassfish.jersey.ext</groupId>
+          <artifactId>jersey-spring5</artifactId>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven3-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>surefire-it</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+    
 
 </project>

--- a/examples/jersey-storage-spring/pom.xml
+++ b/examples/jersey-storage-spring/pom.xml
@@ -100,7 +100,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>com.webcohesion.enunciate</groupId>
@@ -145,7 +145,7 @@
       <groupId>org.glassfish.jersey.containers</groupId>
       <artifactId>jersey-container-servlet</artifactId>
     </dependency>
-        
+
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
@@ -171,7 +171,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-    
+
   <profiles>
     <profile>
       <id>JDK[, 8]</id>
@@ -240,6 +240,5 @@
       </build>
     </profile>
   </profiles>
-    
 
 </project>

--- a/examples/jersey-storage/pom.xml
+++ b/examples/jersey-storage/pom.xml
@@ -11,7 +11,7 @@
   <name>Enunciate - Jersey Storage Example</name>
   <description>Enunciate Example: Jersey Storage </description>
   <packaging>war</packaging>
-
+    
   <build>
     <plugins>
       <plugin>
@@ -49,7 +49,7 @@
       </plugin>
       <plugin>
         <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-maven2-plugin</artifactId>
+        <artifactId>cargo-maven3-plugin</artifactId>
         <executions>
           <execution>
             <id>start-container</id>
@@ -71,7 +71,7 @@
           <container>
             <containerId>tomcat7x</containerId>
             <zipUrlInstaller>
-              <url>http://archive.apache.org/dist/tomcat/tomcat-7/v7.0.79/bin/apache-tomcat-7.0.79.zip</url>
+              <url>http://archive.apache.org/dist/tomcat/tomcat-9/v9.0.58/bin/apache-tomcat-9.0.58.zip</url>
               <extractDir>${basedir}/cargo-installs</extractDir>
             </zipUrlInstaller>
             <append>false</append>
@@ -113,7 +113,14 @@
       <artifactId>enunciate-rt-util</artifactId>
       <version>${enunciate.version}</version>
     </dependency>
-
+        
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+      <version>2.5.6</version>
+      <scope>compile</scope>
+    </dependency>
+    
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
@@ -164,5 +171,49 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
+    
+  <profiles>
+    <profile>
+      <id>[JDK 9, ]</id>
+      <activation>
+        <jdk>[9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven3-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>surefire-it</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+  
 </project>

--- a/examples/jersey-storage/pom.xml
+++ b/examples/jersey-storage/pom.xml
@@ -11,7 +11,7 @@
   <name>Enunciate - Jersey Storage Example</name>
   <description>Enunciate Example: Jersey Storage </description>
   <packaging>war</packaging>
-    
+
   <build>
     <plugins>
       <plugin>
@@ -113,14 +113,14 @@
       <artifactId>enunciate-rt-util</artifactId>
       <version>${enunciate.version}</version>
     </dependency>
-        
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-web</artifactId>
       <version>2.5.6</version>
       <scope>compile</scope>
     </dependency>
-    
+
     <dependency>
       <groupId>javax.xml.bind</groupId>
       <artifactId>jaxb-api</artifactId>
@@ -171,7 +171,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-    
+
   <profiles>
     <profile>
       <id>[JDK 9, ]</id>
@@ -215,5 +215,5 @@
       </build>
     </profile>
   </profiles>
-  
+
 </project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -26,7 +26,7 @@
   </modules>
 
   <properties>
-    <cargo.version>1.6.7</cargo.version>
+    <cargo.version>1.9.0</cargo.version>
     <commons-io.version>1.3.2</commons-io.version>
     <commons-fileupload.version>1.3.1</commons-fileupload.version>
     <enunciate.version>${project.version}</enunciate.version>
@@ -40,7 +40,7 @@
       <plugins>
         <plugin>
           <groupId>org.codehaus.cargo</groupId>
-          <artifactId>cargo-maven2-plugin</artifactId>
+          <artifactId>cargo-maven3-plugin</artifactId>
           <version>${cargo.version}</version>
         </plugin>
       </plugins>

--- a/examples/spring-petclinic/pom.xml
+++ b/examples/spring-petclinic/pom.xml
@@ -12,8 +12,9 @@
   <name>Enunciate - Spring-Web Petclinic Example</name>
   <description>Enunciate Example: Spring-Web Petclinic</description>
   <packaging>war</packaging>
-
+  
   <properties>
+    <antrun-phase>validate</antrun-phase>
     <!-- Spring -->
     <spring-io-platform.version>2.0.8.RELEASE</spring-io-platform.version>
     <persistence-api.version>1.0.2</persistence-api.version>
@@ -95,5 +96,5 @@
       <artifactId>joda-convert</artifactId>
     </dependency>
   </dependencies>
-
+  
 </project>

--- a/examples/spring-petclinic/pom.xml
+++ b/examples/spring-petclinic/pom.xml
@@ -12,7 +12,7 @@
   <name>Enunciate - Spring-Web Petclinic Example</name>
   <description>Enunciate Example: Spring-Web Petclinic</description>
   <packaging>war</packaging>
-  
+
   <properties>
     <antrun-phase>validate</antrun-phase>
     <!-- Spring -->
@@ -96,5 +96,5 @@
       <artifactId>joda-convert</artifactId>
     </dependency>
   </dependencies>
-  
+
 </project>

--- a/gwt-json-overlay/pom.xml
+++ b/gwt-json-overlay/pom.xml
@@ -81,7 +81,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
 
     <dependency>
@@ -126,7 +126,7 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>[JDK 1.9]</id>

--- a/gwt-json-overlay/pom.xml
+++ b/gwt-json-overlay/pom.xml
@@ -81,7 +81,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <dependencies>
 
     <dependency>
@@ -126,5 +126,31 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enunciate</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/java-json-client/pom.xml
+++ b/java-json-client/pom.xml
@@ -31,7 +31,7 @@
                 </taskdef>
 
                 <mkdir dir="${project.build.directory}/enunciate" />
-                
+
                 <enunciate basedir="${basedir}/src/test/samples" configFile="${basedir}/src/test/samples/enunciate.xml" buildDir="${project.build.directory}/enunciate">
                   <include name="**/*.java" />
                   <classpath refid="maven.test.classpath" />
@@ -66,7 +66,7 @@
       </plugin>
     </plugins>
   </build>
-  
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -128,7 +128,7 @@
     </dependency>
 
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>[JDK 1.9]</id>
@@ -138,7 +138,7 @@
           <name>!env.loopback</name>
         </property>
       </activation>
-            
+
       <build>
         <plugins>
           <plugin>

--- a/java-json-client/pom.xml
+++ b/java-json-client/pom.xml
@@ -31,7 +31,7 @@
                 </taskdef>
 
                 <mkdir dir="${project.build.directory}/enunciate" />
-
+                
                 <enunciate basedir="${basedir}/src/test/samples" configFile="${basedir}/src/test/samples/enunciate.xml" buildDir="${project.build.directory}/enunciate">
                   <include name="**/*.java" />
                   <classpath refid="maven.test.classpath" />
@@ -66,7 +66,7 @@
       </plugin>
     </plugins>
   </build>
-
+  
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -128,5 +128,32 @@
     </dependency>
 
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+            
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enunciate</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/java-xml-client/pom.xml
+++ b/java-xml-client/pom.xml
@@ -31,7 +31,7 @@
                 </taskdef>
 
                 <mkdir dir="${project.build.directory}/enunciate" />
-                
+
                 <enunciate basedir="${basedir}/src/test/samples" configFile="${basedir}/src/test/samples/enunciate.xml" buildDir="${project.build.directory}/enunciate">
                   <include name="**/*.java" />
                   <classpath refid="maven.test.classpath" />
@@ -66,7 +66,7 @@
       </plugin>
     </plugins>
   </build>
-    
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -120,7 +120,7 @@
     </dependency>
 
   </dependencies>
-    
+
   <profiles>
     <profile>
       <id>[JDK 1.9]</id>
@@ -137,45 +137,36 @@
         <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
-          <version>1.3.2</version>
         </dependency>
         <dependency>
           <groupId>javax.xml.bind</groupId>
           <artifactId>jaxb-api</artifactId>
-          <version>2.3.1</version>
         </dependency>
         <dependency>
           <groupId>javax.xml.ws</groupId>
           <artifactId>jaxws-api</artifactId>
-          <version>2.3.1</version>
         </dependency>
         <dependency>
           <groupId>javax.jws</groupId>
           <artifactId>javax.jws-api</artifactId>
-          <version>1.1</version>
         </dependency>
         <dependency>
           <groupId>com.sun.xml.ws</groupId>
           <artifactId>jaxws-tools</artifactId>
-          <version>3.0.2</version>
         </dependency>
         <dependency>
           <groupId>com.sun.xml.ws</groupId>
           <artifactId>jaxws-rt</artifactId>
-          <version>3.0.2</version>
         </dependency>
         <dependency>
           <groupId>javax.activation</groupId>
           <artifactId>activation</artifactId>
-          <version>1.1.1</version>
         </dependency>
-           
         <dependency>
           <groupId>com.webcohesion.enunciate</groupId>
           <artifactId>enunciate-core</artifactId>
-          <version>2.13.3</version>
+          <version>${project.version}</version>
         </dependency>
-               
       </dependencies>
       <build>
         <plugins>

--- a/java-xml-client/pom.xml
+++ b/java-xml-client/pom.xml
@@ -31,7 +31,7 @@
                 </taskdef>
 
                 <mkdir dir="${project.build.directory}/enunciate" />
-
+                
                 <enunciate basedir="${basedir}/src/test/samples" configFile="${basedir}/src/test/samples/enunciate.xml" buildDir="${project.build.directory}/enunciate">
                   <include name="**/*.java" />
                   <classpath refid="maven.test.classpath" />
@@ -66,7 +66,7 @@
       </plugin>
     </plugins>
   </build>
-
+    
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -120,5 +120,77 @@
     </dependency>
 
   </dependencies>
-
+    
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+      </properties>
+      <dependencies>
+        <dependency>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+          <version>1.3.2</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+          <version>2.3.1</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.ws</groupId>
+          <artifactId>jaxws-api</artifactId>
+          <version>2.3.1</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.jws</groupId>
+          <artifactId>javax.jws-api</artifactId>
+          <version>1.1</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.ws</groupId>
+          <artifactId>jaxws-tools</artifactId>
+          <version>3.0.2</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.ws</groupId>
+          <artifactId>jaxws-rt</artifactId>
+          <version>3.0.2</version>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+          <version>1.1.1</version>
+        </dependency>
+           
+        <dependency>
+          <groupId>com.webcohesion.enunciate</groupId>
+          <artifactId>enunciate-core</artifactId>
+          <version>2.13.3</version>
+        </dependency>
+               
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enunciate</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/javac-support/pom.xml
+++ b/javac-support/pom.xml
@@ -11,6 +11,10 @@
   <name>Enunciate - Javac Support</name>
   <description>Support classes for working with the Javac API.</description>
 
+  <properties>
+    <antrun-phase>validate</antrun-phase>
+  </properties>
+
   <profiles>
     <profile>
       <id>default-tools.jar</id>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -96,5 +96,34 @@
     </dependency>
 
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-plugin-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-descriptor</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -96,7 +96,7 @@
     </dependency>
 
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>[JDK 1.9]</id>

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <commons-collections.version>3.2.2</commons-collections.version>
     <enforcer-api.version>1.4</enforcer-api.version>
     <flexmark.version>0.62.2</flexmark.version>
-    <freemarker.version>2.3.30</freemarker.version>
+    <freemarker.version>2.3.31</freemarker.version>
     <gwt.version>2.7.0</gwt.version>
     <hamcrest.version>1.3</hamcrest.version>
     <jackson1.version>1.9.13</jackson1.version>
@@ -97,7 +97,7 @@
     <joda-convert.version>2.2.1</joda-convert.version>
     <jsr305.version>3.0.2</jsr305.version>
     <junit.version>4.13.1</junit.version>
-    <lombok.version>1.18.8</lombok.version>
+    <lombok.version>1.18.22</lombok.version>
     <maven-api.version>3.6.0</maven-api.version>
     <maven-filtering.version>1.3</maven-filtering.version>
     <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
@@ -116,7 +116,7 @@
     <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
-    <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
+    <maven-plugin-plugin.version>3.6.4</maven-plugin-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
     <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
@@ -133,7 +133,7 @@
 
     <donations.url>https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=HXSXBXUT63RCG</donations.url>
   </properties>
-
+  
   <build>
     <plugins>
       <plugin>
@@ -163,48 +163,9 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <configuration>
-          <signature>
-            <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java18</artifactId>
-            <version>1.0</version>
-          </signature>
-        </configuration>
-        <executions>
-          <execution>
-            <id>enforce-java-8</id>
-            <phase>test</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <executions>
-          <execution>
-            <id>require-java-8</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>(,1.9)</version>
-                  <message>
-***********
-Enunciate is currently required to be built with Java 8.
-***********
-                  </message>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
           <execution>
             <id>require.full.tests.for.deploy</id>
             <phase>deploy</phase>
@@ -217,11 +178,11 @@ Enunciate is currently required to be built with Java 8.
                   <property>activate.full.tests</property>
                   <regex>true</regex>
                   <message>In order to deploy Enunciate, you must run the full test suite.
-This will include some tricky setup because your environment
-needs to be able to run tests that exercise Enunciate's client-side
-code generation in a variety of different platforms (C#, C, Obj-C,
-PHP, Ruby, etc.). Enable the 'enunciate-full-tests' profile to start
-your path down the rabbit hole.</message>
+                    This will include some tricky setup because your environment
+                    needs to be able to run tests that exercise Enunciate's client-side
+                    code generation in a variety of different platforms (C#, C, Obj-C,
+                    PHP, Ruby, etc.). Enable the 'enunciate-full-tests' profile to start
+                    your path down the rabbit hole.</message>
                 </requireProperty>
               </rules>
             </configuration>
@@ -262,6 +223,11 @@ your path down the rabbit hole.</message>
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>3.3.2</version>
+        </plugin>
         <plugin>
           <groupId>com.github.ekryd.echo-maven-plugin</groupId>
           <artifactId>echo-maven-plugin</artifactId>
@@ -715,11 +681,11 @@ your path down the rabbit hole.</message>
                       <property>activate.full.tests</property>
                       <regex>true</regex>
                       <message>In order to release Enunciate, you must run the full test suite.
-This will include some tricky setup because your environment
-needs to be able to run tests that exercise Enunciate's client-side
-code generation in a variety of different platforms (C#, C, Obj-C,
-PHP, Ruby, etc.). Enable the 'enunciate-full-tests' profile to start
-your path down the rabbit hole.</message>
+                        This will include some tricky setup because your environment
+                        needs to be able to run tests that exercise Enunciate's client-side
+                        code generation in a variety of different platforms (C#, C, Obj-C,
+                        PHP, Ruby, etc.). Enable the 'enunciate-full-tests' profile to start
+                        your path down the rabbit hole.</message>
                     </requireProperty>
                   </rules>
                 </configuration>
@@ -762,6 +728,335 @@ your path down the rabbit hole.</message>
                 <goals>
                   <goal>sign</goal>
                 </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>JDK[, 8]</id>
+      <activation>
+        <jdk>[, 8]</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.10.0</version>
+            <configuration>
+              <source>1.8</source>
+              <target>1.8</target>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M5</version>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>JDK[9, ]</id>
+            
+      <activation>
+        <jdk>[9, ]</jdk>
+      </activation>
+            
+      <properties>
+        <mvn-args>install</mvn-args>
+        <antrun-phase></antrun-phase>
+                
+        <jaxws-ri-rt.version>3.0.2</jaxws-ri-rt.version>
+        <jersey2.version>2.35</jersey2.version>
+                
+      </properties>
+            
+      <dependencyManagement>
+                
+        <dependencies>
+          <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+          </dependency>
+          <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+          <dependency>
+            <groupId>javax.xml.ws</groupId>
+            <artifactId>jaxws-api</artifactId>
+            <version>2.3.1</version>
+          </dependency>
+          <dependency>
+            <groupId>javax.jws</groupId>
+            <artifactId>javax.jws-api</artifactId>
+            <version>1.1</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-tools</artifactId>
+            <version>2.3.5</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>2.3.5</version>
+          </dependency>
+          <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>${jersey2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${jersey2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+            <version>${jersey2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-jaxb</artifactId>
+            <version>${jersey2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>jersey-spring5</artifactId>
+            <version>${jersey2.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>rt</artifactId>
+            <version>2.3.5</version>
+          </dependency>
+        </dependencies>
+      </dependencyManagement>
+            
+            
+      <dependencies>
+        <dependency>
+          <groupId>javax.jws</groupId>
+          <artifactId>javax.jws-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>javax.xml.ws</groupId>
+          <artifactId>jaxws-api</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.webcohesion.enunciate</groupId>
+          <artifactId>enunciate-core</artifactId>
+          <version>2.13.3</version>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-core</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-json-jackson</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-server</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.media</groupId>
+          <artifactId>jersey-media-jaxb</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.ext</groupId>
+          <artifactId>jersey-spring5</artifactId>
+        </dependency>
+      </dependencies>
+        
+            
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.10.0</version>
+            <configuration>
+              <source>1.9</source>
+              <target>1.9</target>
+              <compilerArgs>
+                <arg>--add-exports</arg>
+                <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>3.0.0-M5</version>
+            <configuration>
+              <argLine>
+                --add-opens java.base/java.lang=ALL-UNNAMED
+                --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED
+                --add-opens java.base/java.lang=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+                --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                --add-opens java.base/java.net=ALL-UNNAMED
+              </argLine>
+            </configuration>
+          </plugin>
+                    
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+            
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <version>1.8</version>
+            <executions>
+              <execution>
+                <id>enunciate-antrun</id>
+                <phase>${antrun-phase}</phase>
+                <configuration>
+                  <tasks>
+                    <condition property="_skipTests" value="-DskipTests">
+                      <equals arg1="${skipTests}" arg2="true"/>
+                    </condition>
+                    <exec executable="sh" failonerror="true">
+                      <arg value="-c"/>
+                      <arg value="MAVEN_OPTS='
+                        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED 
+                        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED' 
+                        mvn ${mvn-args} ${_skipTests} -Denv.loopback=true"/>
+                    </exec>
+                  </tasks>
+                </configuration>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>com.webcohesion.enunciate</groupId>
+            <artifactId>enunciate-maven-plugin</artifactId>
+            <version>2.13.3</version>
+            <executions>
+              <execution>
+                <id>assemble</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-resources-plugin</artifactId>
+            <version>3.2.0</version>
+            <executions>
+              <execution>
+                <id>default-resources</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>default-testResources</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.10.0</version>
+            <executions>
+              <execution>
+                <id>default-compile</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>default-testCompile</id>
+                <phase/>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-war-plugin</artifactId>
+            <version>3.3.2</version>
+            <executions>
+              <execution>
+                <id>default-war</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-install-plugin</artifactId>
+            <version>3.0.0-M1</version>
+            <executions>
+              <execution>
+                <id>default-install</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>${maven-surefire-plugin.version}</version>
+            <executions>
+              <execution>
+                <id>default-test</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>surefire-it</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.codehaus.cargo</groupId>
+            <artifactId>cargo-maven3-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>start-container</id>
+                <phase />
+              </execution>
+              <execution>
+                <id>stop-container</id>
+                <phase />
               </execution>
             </executions>
           </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,10 @@
     <!--plugin versions-->
     <echo-maven-plugin.version>1.2.0</echo-maven-plugin.version>
     <nexus-staging-maven-plugin.version>1.6.5</nexus-staging-maven-plugin.version>
+    <maven-resources-plugin.version>3.2.0</maven-resources-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.0.0-M3</maven-surefire-plugin.version>
+    <maven-war-plugin.version>3.3.2</maven-war-plugin.version>
     <maven-plugin-plugin.version>3.6.4</maven-plugin-plugin.version>
     <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.0.0-M1</maven-deploy-plugin.version>
@@ -125,15 +127,17 @@
     <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+    <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
     <animal-sniffer-maven-plugin.version>1.16</animal-sniffer-maven-plugin.version>
     <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
     <build-helper-maven-plugin.version>1.9.1</build-helper-maven-plugin.version>
     <maven-inherit-plugin.version>1.5</maven-inherit-plugin.version>
     <maven-bundle-plugin.version>3.0.1</maven-bundle-plugin.version>
+    <jaxws-maven-plugin.version>2.6</jaxws-maven-plugin.version>
 
     <donations.url>https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&amp;hosted_button_id=HXSXBXUT63RCG</donations.url>
   </properties>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -147,7 +151,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.4</version>
+        <version>${maven-antrun-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -307,6 +311,11 @@
           <groupId>org.ops4j</groupId>
           <artifactId>maven-inherit-plugin</artifactId>
           <version>${maven-inherit-plugin.version}</version>
+        </plugin>
+        <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>jaxws-maven-plugin</artifactId>
+            <version>${jaxws-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -735,91 +744,31 @@
       </build>
     </profile>
     <profile>
-      <id>JDK[, 8]</id>
-      <activation>
-        <jdk>[, 8]</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.0</version>
-            <configuration>
-              <source>1.8</source>
-              <target>1.8</target>
-            </configuration>
-          </plugin>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M5</version>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
       <id>JDK[9, ]</id>
-            
       <activation>
         <jdk>[9, ]</jdk>
       </activation>
-            
+
       <properties>
         <mvn-args>install</mvn-args>
         <antrun-phase></antrun-phase>
-                
-        <jaxws-ri-rt.version>3.0.2</jaxws-ri-rt.version>
+
         <jersey2.version>2.35</jersey2.version>
-                
+        <rt.version>2.3.5</rt.version>
+        <jax.ws.rt.version>3.0.2</jax.ws.rt.version>
+        <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
       </properties>
-            
+
       <dependencyManagement>
-                
         <dependencies>
           <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-            <version>1.3.2</version>
-          </dependency>
-          <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-          <dependency>
-            <groupId>javax.xml.ws</groupId>
-            <artifactId>jaxws-api</artifactId>
-            <version>2.3.1</version>
-          </dependency>
-          <dependency>
-            <groupId>javax.jws</groupId>
-            <artifactId>javax.jws-api</artifactId>
-            <version>1.1</version>
-          </dependency>
-          <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>jaxws-tools</artifactId>
-            <version>2.3.5</version>
-          </dependency>
-          <dependency>
-            <groupId>com.sun.xml.ws</groupId>
-            <artifactId>jaxws-rt</artifactId>
-            <version>2.3.5</version>
-          </dependency>
-          <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
+            <version>${javax.annotation-api.version}</version>
           </dependency>
           <dependency>
             <groupId>org.glassfish.jersey.media</groupId>
             <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey2.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
             <version>${jersey2.version}</version>
           </dependency>
           <dependency>
@@ -840,12 +789,16 @@
           <dependency>
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>rt</artifactId>
-            <version>2.3.5</version>
+            <version>${rt.version}</version>
+          </dependency>
+          <dependency>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>jaxws-rt</artifactId>
+            <version>${jax.ws.rt.version}</version>
           </dependency>
         </dependencies>
       </dependencyManagement>
-            
-            
+
       <dependencies>
         <dependency>
           <groupId>javax.jws</groupId>
@@ -877,10 +830,6 @@
           <artifactId>jersey-media-json-jackson</artifactId>
         </dependency>
         <dependency>
-          <groupId>org.glassfish.jersey.core</groupId>
-          <artifactId>jersey-server</artifactId>
-        </dependency>
-        <dependency>
           <groupId>org.glassfish.jersey.inject</groupId>
           <artifactId>jersey-hk2</artifactId>
         </dependency>
@@ -892,15 +841,18 @@
           <groupId>org.glassfish.jersey.ext</groupId>
           <artifactId>jersey-spring5</artifactId>
         </dependency>
+        <dependency>
+          <groupId>com.sun.xml.ws</groupId>
+          <artifactId>jaxws-rt</artifactId>
+        </dependency>
       </dependencies>
-        
-            
+
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.0</version>
+            <version>${maven-compiler-plugin.version}</version>
             <configuration>
               <source>1.9</source>
               <target>1.9</target>
@@ -913,7 +865,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>3.0.0-M5</version>
+            <version>${maven-surefire-plugin.version}</version>
             <configuration>
               <argLine>
                 --add-opens java.base/java.lang=ALL-UNNAMED
@@ -925,7 +877,6 @@
               </argLine>
             </configuration>
           </plugin>
-                    
         </plugins>
       </build>
     </profile>
@@ -937,13 +888,12 @@
           <name>!env.loopback</name>
         </property>
       </activation>
-            
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-antrun-plugin</artifactId>
-            <version>1.8</version>
+            <version>${maven-antrun-plugin.version}</version>
             <executions>
               <execution>
                 <id>enunciate-antrun</id>
@@ -956,8 +906,8 @@
                     <exec executable="sh" failonerror="true">
                       <arg value="-c"/>
                       <arg value="MAVEN_OPTS='
-                        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED 
-                        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED' 
+                        --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+                        --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED'
                         mvn ${mvn-args} ${_skipTests} -Denv.loopback=true"/>
                     </exec>
                   </tasks>
@@ -982,7 +932,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-resources-plugin</artifactId>
-            <version>3.2.0</version>
+            <version>${maven-resources-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-resources</id>
@@ -997,7 +947,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.0</version>
+            <version>${maven-compiler-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-compile</id>
@@ -1012,7 +962,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-war-plugin</artifactId>
-            <version>3.3.2</version>
+            <version>${maven-war-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-war</id>
@@ -1023,7 +973,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-install-plugin</artifactId>
-            <version>3.0.0-M1</version>
+            <version>${maven-install-plugin.version}</version>
             <executions>
               <execution>
                 <id>default-install</id>
@@ -1046,23 +996,8 @@
               </execution>
             </executions>
           </plugin>
-          <plugin>
-            <groupId>org.codehaus.cargo</groupId>
-            <artifactId>cargo-maven3-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>start-container</id>
-                <phase />
-              </execution>
-              <execution>
-                <id>stop-container</id>
-                <phase />
-              </execution>
-            </executions>
-          </plugin>
         </plugins>
       </build>
     </profile>
   </profiles>
-
 </project>

--- a/slim-maven-plugin/pom.xml
+++ b/slim-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
   <packaging>maven-plugin</packaging>
   <name>Enunciate - Slim Maven Plugin</name>
   <description>Maven plugin for invoking Enunciate without any modules enabled by default.</description>
-
+  
   <build>
     <plugins>
       <plugin>
@@ -124,5 +124,34 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
+  
+  <profiles>
+    <profile>
+      <id>[JDK 1.9]</id>
+      <activation>
+        <jdk>[1.9, ]</jdk>
+        <property>
+          <name>!env.loopback</name>
+        </property>
+      </activation>
+      <properties>
+        <antrun-phase>validate</antrun-phase>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-plugin-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-descriptor</id>
+                <phase />
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>

--- a/slim-maven-plugin/pom.xml
+++ b/slim-maven-plugin/pom.xml
@@ -12,7 +12,7 @@
   <packaging>maven-plugin</packaging>
   <name>Enunciate - Slim Maven Plugin</name>
   <description>Maven plugin for invoking Enunciate without any modules enabled by default.</description>
-  
+
   <build>
     <plugins>
       <plugin>
@@ -124,7 +124,7 @@
       <version>${project.version}</version>
     </dependency>
   </dependencies>
-  
+
   <profiles>
     <profile>
       <id>[JDK 1.9]</id>


### PR DESCRIPTION
This change enables building project using any JDK >= 1.8. 

Building should be easy as running: 
```
JAVA_HOME=/{path.to.java}/jdk-1.8 mvn clean install
JAVA_HOME=/{path.to.java}/jdk-19 mvn clean install
```