### PR TITLE
Issue #1118: update maven-reporting-api to version 3.1.0

### DIFF
--- a/slim-maven-plugin/pom.xml
+++ b/slim-maven-plugin/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.apache.maven.reporting</groupId>
       <artifactId>maven-reporting-api</artifactId>
-      <version>3.0</version>
+      <version>3.1.0</version>
     </dependency>
 
     <dependency>

--- a/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/DocsBaseMojo.java
+++ b/slim-maven-plugin/src/main/java/com/webcohesion/enunciate/mojo/DocsBaseMojo.java
@@ -18,6 +18,8 @@ package com.webcohesion.enunciate.mojo;
 import com.webcohesion.enunciate.Enunciate;
 import com.webcohesion.enunciate.module.DocumentationProviderModule;
 import com.webcohesion.enunciate.module.EnunciateModule;
+
+import org.apache.maven.doxia.sink.Sink;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -26,7 +28,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.reporting.MavenReport;
 import org.apache.maven.reporting.MavenReportException;
-import org.codehaus.doxia.sink.Sink;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,7 +105,7 @@ public class DocsBaseMojo extends ConfigMojo implements MavenReport {
       throw new MavenReportException("Unable to generate Enunciate documentation.", this.siteError);
     }
 
-    //first get rid of the empty page the the site plugin puts there, in order to make room for the documentation.
+    //first get rid of the empty page the site plugin puts there, in order to make room for the documentation.
     new File(getReportOutputDirectory(), this.indexPageName == null ? "index.html" : this.indexPageName).delete();
 
     Enunciate enunciate = (Enunciate) getPluginContext().get(ConfigMojo.ENUNCIATE_PROPERTY);


### PR DESCRIPTION
As of February 2022 there is a new version of the maven-reporting-api released, what is implemented by latest maven-site plugin.
To be able to also keep the maven plugins up to date within our projects, it would be very helpful to update the maven-reporting-api dependency version to (at least) 3.1.0.
Because the main difference is just an updated dependency (org.codehause.doxia -> org.apache.maven.doxia), the fix is simply adapting the related import statement. (I could directly provide a PR).
The only question left is: how to go ahead with adaptions like this? Because this way you would have to update your maven-site-plugin used to version >= 3.11.0