### PR TITLE
include all endpoints when using facets marked for inclusion

### DIFF
--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
@@ -351,7 +351,7 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
     for (RootResource rootResource : rootResources) {
       // NOTE: do not call facetFilter.accept(rootResource) to check if evaluating resourceMethod's in the rootResource can be skipped
       // - If an "included" facet is defined, and not applied to the Resource; then checking facetFilter.accept(rootResource) will
-      //   return false even if the included facet is applied to a method inside the rootResource.
+      //   return false even if the included facet is applied to a method inside the rootResource
       // - ResourceMethods inherit all the facets applied directly to the rootResource, so skipping the check on the rootResource won't cause
       //   problems with included/excluded facets that are applied to the rootResource
       if (rootResource.getResourceMethods().stream().noneMatch(facetFilter::accept)) {
@@ -399,7 +399,7 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
     for (RootResource rootResource : rootResources) {
       // NOTE: do not call facetFilter.accept(rootResource) to check if evaluating resourceMethod's in the rootResource can be skipped
       // - If an "included" facet is defined, and not applied to the Resource; then checking facetFilter.accept(rootResource) will
-      //   return false even if the included facet is applied to a method inside the rootResource.
+      //   return false even if the included facet is applied to a method inside the rootResource
       // - ResourceMethods inherit all the facets applied directly to the rootResource, so skipping the check on the rootResource won't cause
       //   problems with included/excluded facets that are applied to the rootResource
 
@@ -437,7 +437,7 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
     for (RootResource rootResource : rootResources) {
       // NOTE: do not call facetFilter.accept(rootResource) to check if evaluating resourceMethod's in the rootResource can be skipped
       // - If an "included" facet is defined, and not applied to the Resource; then checking facetFilter.accept(rootResource) will
-      //   return false even if the included facet is applied to a method inside the rootResource.
+      //   return false even if the included facet is applied to a method inside the rootResource
       // - ResourceMethods inherit all the facets applied directly to the rootResource, so skipping the check on the rootResource won't cause
       //   problems with included/excluded facets that are applied to the rootResource
 

--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/EnunciateJaxrsContext.java
@@ -349,7 +349,12 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
     Set<String> slugs = new TreeSet<String>();
     FacetFilter facetFilter = registrationContext.getFacetFilter();
     for (RootResource rootResource : rootResources) {
-      if (!facetFilter.accept(rootResource)) {
+      // NOTE: do not call facetFilter.accept(rootResource) to check if evaluating resourceMethod's in the rootResource can be skipped
+      // - If an "included" facet is defined, and not applied to the Resource; then checking facetFilter.accept(rootResource) will
+      //   return false even if the included facet is applied to a method inside the rootResource.
+      // - ResourceMethods inherit all the facets applied directly to the rootResource, so skipping the check on the rootResource won't cause
+      //   problems with included/excluded facets that are applied to the rootResource
+      if (rootResource.getResourceMethods().stream().noneMatch(facetFilter::accept)) {
         continue;
       }
 
@@ -377,6 +382,7 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
       ResourceGroup group = new ResourceClassResourceGroupImpl(rootResource, slug, contextPath, registrationContext);
 
       if (!group.getResources().isEmpty()) {
+        // group.getResources() should never be empty since we did a getResourceMethods().stream().noneMatch() pre-check at the start of the loop
         resourceGroups.add(group);
       }
     }
@@ -391,9 +397,11 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
 
     FacetFilter facetFilter = registrationContext.getFacetFilter();
     for (RootResource rootResource : rootResources) {
-      if (!facetFilter.accept(rootResource)) {
-        continue;
-      }
+      // NOTE: do not call facetFilter.accept(rootResource) to check if evaluating resourceMethod's in the rootResource can be skipped
+      // - If an "included" facet is defined, and not applied to the Resource; then checking facetFilter.accept(rootResource) will
+      //   return false even if the included facet is applied to a method inside the rootResource.
+      // - ResourceMethods inherit all the facets applied directly to the rootResource, so skipping the check on the rootResource won't cause
+      //   problems with included/excluded facets that are applied to the rootResource
 
       for (ResourceMethod method : rootResource.getResourceMethods(true)) {
         if (facetFilter.accept(method)) {
@@ -427,9 +435,11 @@ public class EnunciateJaxrsContext extends EnunciateModuleContext {
 
     FacetFilter facetFilter = registrationContext.getFacetFilter();
     for (RootResource rootResource : rootResources) {
-      if (!facetFilter.accept(rootResource)) {
-        continue;
-      }
+      // NOTE: do not call facetFilter.accept(rootResource) to check if evaluating resourceMethod's in the rootResource can be skipped
+      // - If an "included" facet is defined, and not applied to the Resource; then checking facetFilter.accept(rootResource) will
+      //   return false even if the included facet is applied to a method inside the rootResource.
+      // - ResourceMethods inherit all the facets applied directly to the rootResource, so skipping the check on the rootResource won't cause
+      //   problems with included/excluded facets that are applied to the rootResource
 
       for (ResourceMethod method : rootResource.getResourceMethods(true)) {
         if (facetFilter.accept(method)) {

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/EnunciateSpringWebContext.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/EnunciateSpringWebContext.java
@@ -145,8 +145,14 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
     List<ResourceGroup> resourceGroups = new ArrayList<ResourceGroup>();
     Set<String> slugs = new TreeSet<String>();
     FacetFilter facetFilter = registrationContext.getFacetFilter();
+
     for (SpringController springController : controllers) {
-      if (!facetFilter.accept(springController)) {
+      // NOTE: do not call facetFilter.accept(springController) to check if evaluating RequestMapping's in the controller can be skipped
+      // - If an "included" facet is defined, and not applied to the controller; then checking facetFilter.accept(springController) will
+      //   return false even if the included facet is applied to a RequestMapping inside the controller.
+      // - RequestMappings inherit all the facets applied directly to the controller, so skipping the check on the controller won't cause
+      //   problems with included/excluded facets that are applied to the controller
+      if (springController.getRequestMappings().stream().noneMatch(facetFilter::accept)) {
         continue;
       }
 
@@ -166,6 +172,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
       ResourceGroup group = new ResourceClassResourceGroupImpl(springController, slug, relativeContextPath, registrationContext);
 
       if (!group.getResources().isEmpty()) {
+        // group.getResources() should never be empty since we did a getRequestMappings().stream().noneMatch() pre-check at the start of the loop
         resourceGroups.add(group);
       }
     }
@@ -180,9 +187,11 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
 
     FacetFilter facetFilter = registrationContext.getFacetFilter();
     for (SpringController springController : controllers) {
-      if (!facetFilter.accept(springController)) {
-        continue;
-      }
+      // NOTE: do not call facetFilter.accept(springController) to check if evaluating RequestMapping's in the controller can be skipped
+      // - If an "included" facet is defined, and not applied to the controller; then checking facetFilter.accept(springController) will
+      //   return false even if the included facet is applied to a RequestMapping inside the controller.
+      // - RequestMappings inherit all the facets applied directly to the controller, so skipping the check on the controller won't cause
+      //   problems with included/excluded facets that are applied to the controller
 
       for (RequestMapping method : springController.getRequestMappings()) {
         if (facetFilter.accept(method)) {
@@ -208,9 +217,11 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
 
     FacetFilter facetFilter = registrationContext.getFacetFilter();
     for (SpringController springController : controllers) {
-      if (!facetFilter.accept(springController)) {
-        continue;
-      }
+      // NOTE: do not call facetFilter.accept(springController) to check if evaluating RequestMapping's in the controller can be skipped
+      // - If an "included" facet is defined, and not applied to the controller; then checking facetFilter.accept(springController) will
+      //   return false even if the included facet is applied to a RequestMapping inside the controller.
+      // - RequestMappings inherit all the facets applied directly to the controller, so skipping the check on the controller won't cause
+      //   problems with included/excluded facets that are applied to the controller
 
       com.webcohesion.enunciate.metadata.rs.ResourceGroup controllerAnnotation = null;
       boolean controllerAnnotationEvaluated = false;

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/EnunciateSpringWebContext.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/EnunciateSpringWebContext.java
@@ -149,7 +149,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
     for (SpringController springController : controllers) {
       // NOTE: do not call facetFilter.accept(springController) to check if evaluating RequestMapping's in the controller can be skipped
       // - If an "included" facet is defined, and not applied to the controller; then checking facetFilter.accept(springController) will
-      //   return false even if the included facet is applied to a RequestMapping inside the controller.
+      //   return false even if the included facet is applied to a RequestMapping inside the controller
       // - RequestMappings inherit all the facets applied directly to the controller, so skipping the check on the controller won't cause
       //   problems with included/excluded facets that are applied to the controller
       if (springController.getRequestMappings().stream().noneMatch(facetFilter::accept)) {
@@ -189,7 +189,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
     for (SpringController springController : controllers) {
       // NOTE: do not call facetFilter.accept(springController) to check if evaluating RequestMapping's in the controller can be skipped
       // - If an "included" facet is defined, and not applied to the controller; then checking facetFilter.accept(springController) will
-      //   return false even if the included facet is applied to a RequestMapping inside the controller.
+      //   return false even if the included facet is applied to a RequestMapping inside the controller
       // - RequestMappings inherit all the facets applied directly to the controller, so skipping the check on the controller won't cause
       //   problems with included/excluded facets that are applied to the controller
 
@@ -219,7 +219,7 @@ public class EnunciateSpringWebContext extends EnunciateModuleContext {
     for (SpringController springController : controllers) {
       // NOTE: do not call facetFilter.accept(springController) to check if evaluating RequestMapping's in the controller can be skipped
       // - If an "included" facet is defined, and not applied to the controller; then checking facetFilter.accept(springController) will
-      //   return false even if the included facet is applied to a RequestMapping inside the controller.
+      //   return false even if the included facet is applied to a RequestMapping inside the controller
       // - RequestMappings inherit all the facets applied directly to the controller, so skipping the check on the controller won't cause
       //   problems with included/excluded facets that are applied to the controller
 


### PR DESCRIPTION
when using`<facets><include name="..."/></facets>` make sure to include in the api-docs all endpoints which contain the facet/annotation (even if the annotation is applied only to the endpoint, and to the controller)

fixes #1133 