### PR TITLE
fix detection of jakarta constraints

### DIFF
--- a/core/src/main/java/com/webcohesion/enunciate/util/BeanValidationUtils.java
+++ b/core/src/main/java/com/webcohesion/enunciate/util/BeanValidationUtils.java
@@ -122,8 +122,13 @@ public class BeanValidationUtils {
         Element annotationElement = annotationType.asElement();
         if (annotationElement != null) {
           Element pckg = annotationElement.getEnclosingElement();
-          if (pckg instanceof PackageElement && ((PackageElement) pckg).getQualifiedName().toString().equals("javax.validation.constraints")) {
-            return true;
+          if (pckg instanceof PackageElement) {
+            String packageQualifiedName = ((PackageElement) pckg).getQualifiedName().toString();
+            boolean nameEqualsJavax = packageQualifiedName.equals("javax.validation.constraints");
+            boolean nameEqualsJakarta = packageQualifiedName.equals("jakarta.validation.constraints");
+            if (nameEqualsJakarta || nameEqualsJavax) {
+              return true;
+            }
           }
         }
       }


### PR DESCRIPTION
in some situations, when there are only annotations of the `jakarta` namespace on a field, the "constraints" column is not rendered in the HTML docu. this PR fixes it.

@stoicflame if i should provide some tests, plz give me a hint, where. thx!

related to https://github.com/stoicflame/enunciate/issues/1122#issuecomment-1378454302