### PR TITLE
Fix java.util.ConcurrentModificationException in enunciate-lombok.

### DIFF
--- a/lombok/src/main/java/com/webcohesion/enunciate/modules/lombok/LombokDecoration.java
+++ b/lombok/src/main/java/com/webcohesion/enunciate/modules/lombok/LombokDecoration.java
@@ -5,6 +5,7 @@ import com.webcohesion.enunciate.javac.decorations.ElementDecoration;
 import com.webcohesion.enunciate.javac.decorations.element.DecoratedElement;
 import com.webcohesion.enunciate.javac.decorations.element.DecoratedExecutableElement;
 import com.webcohesion.enunciate.javac.decorations.element.DecoratedTypeElement;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,7 +27,7 @@ import java.util.function.Function;
  */
 public class LombokDecoration extends SimpleElementVisitor9<Void, DecoratedProcessingEnvironment> implements ElementDecoration {
 
-  private final Map<String, List<DecoratedExecutableElement>> CACHE = new TreeMap<>();
+  private final Map<String, List<DecoratedExecutableElement>> CACHE = new ConcurrentHashMap<>();
 
   @Override
   public void applyTo(DecoratedElement e, DecoratedProcessingEnvironment env) {


### PR DESCRIPTION
java.util.ConcurrentModificationException: getLombokMethodDecorations(org.familysearch.rmshazelcast.aws.RootController (org.familysearch.rmshazelcast.aws.RootController), com.webcohesion.enunciate.javac.decorations.DecoratedProcessingEnvironment@5b265379)

I stumbled upon this exception when upgrading to enunciate 2.15.0.
I got 15/16 repos successfully upgraded. I think it is somewhat rare. 

This is the only one that failed: https://github.com/fs-eng/rms-hazelcast/pull/4/files