### PR TITLE
feat: enables 'summary' tag with the help of '@ApiOperation' annotation

### DIFF
--- a/spring-web/pom.xml
+++ b/spring-web/pom.xml
@@ -44,6 +44,10 @@
       <groupId>javax.annotation</groupId>
       <artifactId>jsr250-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+    </dependency>
   </dependencies>
 
 </project>

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/MethodImpl.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/api/impl/MethodImpl.java
@@ -23,6 +23,7 @@ import com.webcohesion.enunciate.javac.decorations.element.ElementUtils;
 import com.webcohesion.enunciate.javac.javadoc.JavaDoc;
 import com.webcohesion.enunciate.metadata.swagger.OperationId;
 import com.webcohesion.enunciate.modules.spring_web.model.*;
+import io.swagger.annotations.ApiOperation;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.VariableElement;
@@ -84,6 +85,10 @@ public class MethodImpl implements Method {
 
   @Override
   public String getSummary() {
+    ApiOperation apiOperation = this.getResource().getAnnotation(ApiOperation.class);
+    if (apiOperation != null) {
+      return apiOperation.value();
+    }
     return null;
   }
 


### PR DESCRIPTION
The below code shows how the `summary` tag is generated
```
[#if method.summary?? && method.summary?length > 0]
"summary" : "${method.summary}",
[/#if]
```
as by default, `MethodImpl` is returning `null` for the `summary`, we can not override this with anything. As per suggestion [here](https://github.com/stoicflame/enunciate/issues/1025), we have to use swagger's `ApiOperation` annotation, but by default, it is not supported as well, so this PR is going to fix the issue and we are going to add `summary` tag into generated `swagger.json` file.
