### PR TITLE
Add support for annotations on records

### DIFF
--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/DecoratedElement.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/DecoratedElement.java
@@ -307,13 +307,28 @@ public class DecoratedElement<E extends Element> implements Element {
   public Name getSimpleName() {
     return this.delegate.getSimpleName();
   }
-  
+
   public String getSimpleNameString() {
     return getSimpleName().toString();
   }
 
   public E getDelegate() {
     return this.delegate;
+  }
+
+  /**
+   * If this element is a RECORD_COMPONENT get the accessor for it, otherwise return null.
+   *
+   * @return the accessor if applicable, null otherwise
+   */
+  public Element getRecordAccessor() {
+    if (getKind() == ElementKind.RECORD_COMPONENT) {
+      RecordComponentElement componentElement = (RecordComponentElement) getDelegate();
+      return ElementDecorator.decorate(componentElement.getAccessor(), env);
+    }
+    else {
+      return null;
+    }
   }
 
   //Inherited.

--- a/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/ElementUtils.java
+++ b/javac-support/src/main/java/com/webcohesion/enunciate/javac/decorations/element/ElementUtils.java
@@ -155,8 +155,11 @@ public class ElementUtils {
     if (clazz.getKind() == ElementKind.RECORD) {
       List<Element> elements = new ArrayList<>();
       for (Element element : clazz.getEnclosedElements()) {
-        if (element.getKind() == ElementKind.RECORD_COMPONENT) {
-          elements.add(element);
+        if (element instanceof DecoratedElement<?> decoratedElement) {
+          Element accessor = decoratedElement.getRecordAccessor();
+          if (accessor != null) {
+            elements.add(accessor);
+          }
         }
       }
       return elements;


### PR DESCRIPTION
The record support added a couple of weeks ago seems to ignore annotations on the record components. Digging in to it it seems that these are added to the accessor method of the record.

This is a small PR that returns the accessors instead of the component element fields. 