### PR TITLE
Wire securityScheme "in" and "name" through to the Swagger spec template

### DIFF
--- a/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/SwaggerModule.java
+++ b/swagger/src/main/java/com/webcohesion/enunciate/modules/swagger/SwaggerModule.java
@@ -308,7 +308,8 @@ public class SwaggerModule extends BasicGeneratingModule implements ApiFeaturePr
       if (id != null) {
         return new SecurityScheme(id, securityScheme.getString("[@name]"),
             Optional.ofNullable(securityScheme.getString("[@description]")),
-            Optional.ofNullable(securityScheme.getString("[@type]")).orElse("http"), null,
+            Optional.ofNullable(securityScheme.getString("[@type]")).orElse("http"),
+            Optional.ofNullable(securityScheme.getString("[@in]")).orElse(null),
             Optional.ofNullable(securityScheme.getString("[@scheme]")).orElse(id.replace("Auth", "")), null, null,
             null);
       }

--- a/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/openapi.fmt
+++ b/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/openapi.fmt
@@ -122,6 +122,8 @@
       "${scheme.schemeId}": {
         "type": "${scheme.type}",
         "scheme": "${scheme.scheme}"
+        [#if scheme.in??], "in": "${scheme.in}" [/#if]
+        [#if scheme.name??], "name": "${scheme.name}" [/#if]
       }[#if scheme_has_next],[/#if]
     [/#items]
     }


### PR DESCRIPTION
Hello! I was happy to see that `securityScheme` s were supported in Enunciate, but then I realized very few of the different schemes and attributes of the Swagger module were actually wired all the way through. It looks like it was set up for `Bearer` for OAuth2 and that was it.

This PR carries through `in` and `name` which allows for another common use case: a simple API key in a header. My example usage:

```xml
        <swagger disabled="false" includeApplicationPath="true">
			<securityScheme id="ApiKeyAuth" scheme="Digest" type="apiKey" in="header" name="x-api-key" />
        </swagger>
```

(I'm not sure if `Digest` is right but it works as far as creating the right Swagger spec)