### PR TITLE
fix: method-level @RolesAllowed overrides class-level in generated docs

### DIFF
--- a/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceMethod.java
+++ b/jaxrs/src/main/java/com/webcohesion/enunciate/modules/jaxrs/model/ResourceMethod.java
@@ -864,6 +864,7 @@ public class ResourceMethod extends DecoratedExecutableElement implements HasFac
     RolesAllowed rolesAllowed = getAnnotation(RolesAllowed.class);
     if (rolesAllowed != null) {
       Collections.addAll(roles, rolesAllowed.value());
+      return roles;
     }
 
     Resource parent = getParent();

--- a/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/model/RequestMapping.java
+++ b/spring-web/src/main/java/com/webcohesion/enunciate/modules/spring_web/model/RequestMapping.java
@@ -697,6 +697,7 @@ public class RequestMapping extends DecoratedExecutableElement implements HasFac
     RolesAllowed rolesAllowed = getAnnotation(RolesAllowed.class);
     if (rolesAllowed != null) {
       Collections.addAll(roles, rolesAllowed.value());
+      return roles;
     }
 
     SpringController parent = getParent();


### PR DESCRIPTION
## Problem

When a JAX-RS resource class has a class-level `@RolesAllowed` and a method has its own method-level `@RolesAllowed`, the generated documentation shows the **union** of both sets instead of only the method-level roles.

**Example:**
```java
@RolesAllowed({"administrator", "group"})  // class-level
public class MyResource {

    @RolesAllowed({"test", "viewer"})  // method-level — should override class-level
    public Response myMethod() { ... }
}
```

Current docs show: `administrator, group, test, viewer`  
Expected docs show: `test, viewer`

## Root cause

`ResourceMethod.getSecurityRoles()` (jaxrs) and `RequestMapping.getSecurityRoles()` (spring-web) always append the parent (class-level) roles even when a method-level annotation is present, producing a union instead of an override.

## Fix

Return early when a method-level `@RolesAllowed` is found. One `return roles` added in each of the two affected files.

## Spec references

The override semantics are unambiguous and consistent across all versions of the spec:

**Jakarta Annotations 3.0 (latest)** — §3.11:
> *"If applied at both the class and method level, the method value overrides the class value."*

**Jakarta Annotations 3.0 (latest)** — §3.14:
> *"If the PermitAll, DenyAll and RolesAllowed annotations are applied on methods of a class, then the method level annotations take precedence (at the corresponding methods) over any class level annotations."*

- Specification: https://jakarta.ee/specifications/annotations/3.0/annotations-spec-3.0.html
- API docs: https://jakarta.ee/specifications/annotations/3.0/
- Jakarta Annotations 2.1 (previous): https://jakarta.ee/specifications/annotations/2.1/annotations-spec-2.1.html

## Scope

- Only affects `jakarta.annotation.security.RolesAllowed` (the only annotation Enunciate currently reads for security roles)
- **Behaviour change in documentation output**: projects using class-level + method-level `@RolesAllowed` together will see fewer roles documented — but the result will now match what the container actually enforces at runtime