### PR TITLE
Discriminator is now an object in OAI 3 not just a simple string property as it was in OAI 2

### DIFF
--- a/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/openapi.fmt
+++ b/swagger/src/main/resources/com/webcohesion/enunciate/modules/swagger/openapi.fmt
@@ -272,7 +272,9 @@
 [/@file]
 [#macro describeDataType dataType syntaxIsJson]
   [#if dataType.typeIdProperty??]
-"discriminator" : "${dataType.typeIdProperty}",
+"discriminator" : {
+  "propertyName" : "${dataType.typeIdProperty}"
+},
   [/#if]
 "type" : "${baseDatatypeNameFor(dataType)}",
   [#if dataType.xmlName??]


### PR DESCRIPTION
Hello! I'm trying to get `@JsonSubType` to work, and we hit a snag when OpenAPI generator tried to use the Enunciate generated spec:
> -attribute components.schemas.Foo.discriminator is not of type object

That's because discriminator was refactored to be a more complex object for OAI 3. See https://swagger.io/docs/specification/v3_0/data-models/inheritance-and-polymorphism/

Enunciate is claiming to generate 3.0.3 compliant spec so I assume this was a holdover from 2 and should be unconditionally fixed?